### PR TITLE
add mod update and chart convert deep link handlers

### DIFF
--- a/src/Euterpe.Abstractions/IModManageService.cs
+++ b/src/Euterpe.Abstractions/IModManageService.cs
@@ -7,8 +7,8 @@ public interface IModManageService
     ModDto? FindModByName(string name);
     Task InstallModAsync(ModDto mod);
     Task UpdateModAsync(ModDto mod);
-    Task UpdateAllModsAsync();
     Task ReinstallModAsync(ModDto mod);
     Task UninstallModAsync(ModDto mod);
     Task ToggleModAsync(ModDto mod);
+    Task UpdateAllModsAsync();
 }

--- a/src/Euterpe.Abstractions/IModManageService.cs
+++ b/src/Euterpe.Abstractions/IModManageService.cs
@@ -7,6 +7,7 @@ public interface IModManageService
     ModDto? FindModByName(string name);
     Task InstallModAsync(ModDto mod);
     Task UpdateModAsync(ModDto mod);
+    Task UpdateAllModsAsync();
     Task ReinstallModAsync(ModDto mod);
     Task UninstallModAsync(ModDto mod);
     Task ToggleModAsync(ModDto mod);

--- a/src/Euterpe.Core/Services/ModManageService/ModManageService.Core.cs
+++ b/src/Euterpe.Core/Services/ModManageService/ModManageService.Core.cs
@@ -123,4 +123,12 @@ internal sealed partial class ModManageService
             NotificationService.ErrorLight(Notification_Content_Mod_Toggle_Failed, mod.Name);
         }
     }
+
+    private async Task RunExclusiveAsync(ModDto mod, Func<Task> action) =>
+        await _singleFlight.RunAsync(mod.Name, async () =>
+        {
+            mod.IsProcessing = true;
+            await action().ConfigureAwait(false);
+            mod.IsProcessing = false;
+        }).ConfigureAwait(false);
 }

--- a/src/Euterpe.Core/Services/ModManageService/ModManageService.cs
+++ b/src/Euterpe.Core/Services/ModManageService/ModManageService.cs
@@ -23,6 +23,17 @@ internal sealed partial class ModManageService : IModManageService
 
     public Task UpdateModAsync(ModDto mod) => RunExclusiveAsync(mod, () => UpdateModCoreAsync(mod));
 
+    public async Task UpdateAllModsAsync()
+    {
+        var outdatedMods = _sourceCache.Items.Where(mod => mod.State is ModState.Outdated).ToArray();
+        Logger.ZLogInformation($"Updating {outdatedMods.Length} outdated mod(s)");
+
+        foreach (var mod in outdatedMods)
+        {
+            await UpdateModAsync(mod).ConfigureAwait(false);
+        }
+    }
+
     public Task ReinstallModAsync(ModDto mod) => RunExclusiveAsync(mod, () => ReinstallModCoreAsync(mod));
 
     public Task UninstallModAsync(ModDto mod) => RunExclusiveAsync(mod, () => UninstallModCoreAsync(mod));

--- a/src/Euterpe.Core/Services/ModManageService/ModManageService.cs
+++ b/src/Euterpe.Core/Services/ModManageService/ModManageService.cs
@@ -23,6 +23,12 @@ internal sealed partial class ModManageService : IModManageService
 
     public Task UpdateModAsync(ModDto mod) => RunExclusiveAsync(mod, () => UpdateModCoreAsync(mod));
 
+    public Task ReinstallModAsync(ModDto mod) => RunExclusiveAsync(mod, () => ReinstallModCoreAsync(mod));
+
+    public Task UninstallModAsync(ModDto mod) => RunExclusiveAsync(mod, () => UninstallModCoreAsync(mod));
+
+    public Task ToggleModAsync(ModDto mod) => RunExclusiveAsync(mod, () => ToggleModCoreAsync(mod));
+
     public async Task UpdateAllModsAsync()
     {
         var outdatedMods = _sourceCache.Items.Where(mod => mod.State is ModState.Outdated).ToArray();
@@ -33,20 +39,6 @@ internal sealed partial class ModManageService : IModManageService
             await UpdateModAsync(mod).ConfigureAwait(false);
         }
     }
-
-    public Task ReinstallModAsync(ModDto mod) => RunExclusiveAsync(mod, () => ReinstallModCoreAsync(mod));
-
-    public Task UninstallModAsync(ModDto mod) => RunExclusiveAsync(mod, () => UninstallModCoreAsync(mod));
-
-    public Task ToggleModAsync(ModDto mod) => RunExclusiveAsync(mod, () => ToggleModCoreAsync(mod));
-
-    private async Task RunExclusiveAsync(ModDto mod, Func<Task> action) =>
-        await _singleFlight.RunAsync(mod.Name, async () =>
-        {
-            mod.IsProcessing = true;
-            await action().ConfigureAwait(false);
-            mod.IsProcessing = false;
-        }).ConfigureAwait(false);
 
     #region Injections
 

--- a/src/Euterpe/Services/DeepLinkService/DeepLinkService.Chart.cs
+++ b/src/Euterpe/Services/DeepLinkService/DeepLinkService.Chart.cs
@@ -2,7 +2,7 @@ namespace Euterpe.Services;
 
 public sealed partial class DeepLinkService
 {
-    private Task HandleChartActionAsync(string path)
+    private async Task HandleChartActionAsync(string path)
     {
         var segments = path.Split('/', 2);
 
@@ -17,7 +17,5 @@ public sealed partial class DeepLinkService
                 Logger.ZLogWarning($"Unknown chart deep link path: {path}");
                 break;
         }
-
-        return Task.CompletedTask;
     }
 }

--- a/src/Euterpe/Services/DeepLinkService/DeepLinkService.Chart.cs
+++ b/src/Euterpe/Services/DeepLinkService/DeepLinkService.Chart.cs
@@ -1,0 +1,23 @@
+namespace Euterpe.Services;
+
+public sealed partial class DeepLinkService
+{
+    private Task HandleChartActionAsync(string path)
+    {
+        var segments = path.Split('/', 2);
+
+        switch (segments)
+        {
+            case ["convert"]:
+                // Placeholder: legacy chart conversion (CustomAlbums -> epk) is not implemented yet.
+                Logger.ZLogInformation($"Chart convert deep link received (not implemented yet)");
+                break;
+
+            default:
+                Logger.ZLogWarning($"Unknown chart deep link path: {path}");
+                break;
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Euterpe/Services/DeepLinkService/DeepLinkService.Mod.cs
+++ b/src/Euterpe/Services/DeepLinkService/DeepLinkService.Mod.cs
@@ -12,6 +12,14 @@ public sealed partial class DeepLinkService
                 await InstallModByNameAsync(modName).ConfigureAwait(false);
                 break;
 
+            case ["update"]:
+                await ModManageService.UpdateAllModsAsync().ConfigureAwait(false);
+                break;
+
+            case ["update", var modName]:
+                await UpdateModByNameAsync(modName).ConfigureAwait(false);
+                break;
+
             case ["uninstall", var modName]:
                 await UninstallModByNameAsync(modName).ConfigureAwait(false);
                 break;
@@ -38,6 +46,24 @@ public sealed partial class DeepLinkService
         }
 
         await ModManageService.InstallModAsync(mod).ConfigureAwait(false);
+    }
+
+    private async Task UpdateModByNameAsync(string modName)
+    {
+        var mod = ModManageService.FindModByName(modName);
+        if (mod is null)
+        {
+            Logger.ZLogWarning($"Deep link: mod '{modName}' not found");
+            return;
+        }
+
+        if (!mod.IsLocal)
+        {
+            Logger.ZLogInformation($"Deep link: mod '{modName}' is not installed");
+            return;
+        }
+
+        await ModManageService.UpdateModAsync(mod).ConfigureAwait(false);
     }
 
     private async Task UninstallModByNameAsync(string modName)

--- a/src/Euterpe/Services/DeepLinkService/DeepLinkService.Mod.cs
+++ b/src/Euterpe/Services/DeepLinkService/DeepLinkService.Mod.cs
@@ -63,6 +63,12 @@ public sealed partial class DeepLinkService
             return;
         }
 
+        if (mod.State is not ModState.Outdated)
+        {
+            Logger.ZLogInformation($"Deep link: mod '{modName}' is not outdated and cannot be updated");
+            return;
+        }
+
         await ModManageService.UpdateModAsync(mod).ConfigureAwait(false);
     }
 

--- a/src/Euterpe/Services/DeepLinkService/DeepLinkService.cs
+++ b/src/Euterpe/Services/DeepLinkService/DeepLinkService.cs
@@ -50,6 +50,10 @@ public sealed partial class DeepLinkService
                 await HandleModActionAsync(path).ConfigureAwait(false);
                 break;
 
+            case "chart":
+                await HandleChartActionAsync(path).ConfigureAwait(false);
+                break;
+
             case "auth":
                 await HandleAuthCallbackAsync(query).ConfigureAwait(false);
                 break;

--- a/tests/Euterpe.Headless.Tests/Services/DeepLinkServiceTest.cs
+++ b/tests/Euterpe.Headless.Tests/Services/DeepLinkServiceTest.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using Autofac;
 using Euterpe.Abstractions;
+using Euterpe.Models.Mods;
 using Euterpe.Services;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -15,9 +16,16 @@ public sealed class DeepLinkServiceTest : HeadlessTest
     private static DeepLinkService NewService(
         IAuthService? auth = null,
         IDeepLinkSetup? setup = null,
-        MockLogger<DeepLinkService>? logger = null)
+        MockLogger<DeepLinkService>? logger = null,
+        IModManageService? modManageService = null)
     {
-        var container = new ContainerBuilder().Build();
+        var builder = new ContainerBuilder();
+        if (modManageService is not null)
+        {
+            builder.RegisterInstance(modManageService).As<IModManageService>();
+        }
+
+        var container = builder.Build();
         return new DeepLinkService
         {
             NavigationService = new NavigationService
@@ -162,5 +170,83 @@ public sealed class DeepLinkServiceTest : HeadlessTest
         auth.CompleteLoginAsync("abc123").WasCalled(Times.Once);
         auth.LoginAsync().WasCalled(Times.Once);
         await Assert.That(logger.Entries.Any(e => e.LogLevel == LogLevel.Error && e.Message.Contains("Auth callback failed"))).IsTrue();
+    }
+
+    // Private HandleModActionAsync / HandleChartActionAsync tests (bypass the NavigationService.Ready
+    // gate + ActivateMainWindow sitting between HandleUri and the per-domain dispatch).
+
+    private static Task InvokeModAction(DeepLinkService service, string path) =>
+        (Task)typeof(DeepLinkService)
+            .GetMethod("HandleModActionAsync", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(service, [path])!;
+
+    private static Task InvokeChartAction(DeepLinkService service, string path) =>
+        (Task)typeof(DeepLinkService)
+            .GetMethod("HandleChartActionAsync", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(service, [path])!;
+
+    [Test]
+    public async Task HandleModAction_Update_WithoutName_UpdatesAllMods()
+    {
+        var mods = IModManageService.Mock();
+        var service = NewService(modManageService: mods);
+
+        await InvokeModAction(service, "update");
+
+        using var _ = Assert.Multiple();
+        mods.UpdateAllModsAsync().WasCalled(Times.Once);
+        mods.UpdateModAsync(Any<ModDto>()).WasCalled(Times.Never);
+    }
+
+    [Test]
+    public async Task HandleModAction_Update_NamedInstalledMod_UpdatesThatMod()
+    {
+        var mods = IModManageService.Mock();
+        var installed = new ModDto { Name = "Euterpe", FileNameWithoutExtension = "Euterpe" };
+        mods.FindModByName("Euterpe").Returns(installed);
+        var service = NewService(modManageService: mods);
+
+        await InvokeModAction(service, "update/Euterpe");
+
+        using var _ = Assert.Multiple();
+        mods.UpdateModAsync(installed).WasCalled(Times.Once);
+        mods.UpdateAllModsAsync().WasCalled(Times.Never);
+    }
+
+    [Test]
+    public async Task HandleModAction_Update_NamedNotInstalledMod_DoesNotUpdate()
+    {
+        var mods = IModManageService.Mock();
+        var notInstalled = new ModDto { Name = "Euterpe" };
+        mods.FindModByName("Euterpe").Returns(notInstalled);
+        var service = NewService(modManageService: mods);
+
+        await InvokeModAction(service, "update/Euterpe");
+
+        mods.UpdateModAsync(Any<ModDto>()).WasCalled(Times.Never);
+    }
+
+    [Test]
+    public async Task HandleChartAction_Convert_LogsPlaceholderWithoutWarning()
+    {
+        var logger = Mock.Logger<DeepLinkService>();
+        var service = NewService(logger: logger);
+
+        await InvokeChartAction(service, "convert");
+
+        using var _ = Assert.Multiple();
+        await Assert.That(logger.Entries.Any(e => e.LogLevel == LogLevel.Information && e.Message.Contains("Chart convert"))).IsTrue();
+        await Assert.That(logger.Entries.Any(e => e.LogLevel == LogLevel.Warning)).IsFalse();
+    }
+
+    [Test]
+    public async Task HandleChartAction_UnknownPath_LogsWarning()
+    {
+        var logger = Mock.Logger<DeepLinkService>();
+        var service = NewService(logger: logger);
+
+        await InvokeChartAction(service, "bogus");
+
+        await Assert.That(logger.Entries.Any(e => e.LogLevel == LogLevel.Warning && e.Message.Contains("Unknown chart deep link"))).IsTrue();
     }
 }

--- a/tests/Euterpe.Tests/Core/Services/ModManageService/ModManageServiceTest.Update.cs
+++ b/tests/Euterpe.Tests/Core/Services/ModManageService/ModManageServiceTest.Update.cs
@@ -52,6 +52,62 @@ public sealed partial class ModManageServiceTest
     }
 
     [Test]
+    public async Task UpdateAllModsAsync_UpdatesOnlyOutdatedMods()
+    {
+        var outdated = CreateInstalledMod(name: "Outdated", fileName: "Outdated.dll");
+        var upToDate = CreateInstalledMod(name: "UpToDate", fileName: "UpToDate.dll");
+        upToDate.SHA256 = "shared-sha";
+
+        var fileSystemServiceMock = IFileSystemService.Mock();
+        fileSystemServiceMock.TryDeleteFile(Any<string>(), Any<DeleteOption>()).Returns(true);
+
+        var downloadManagerMock = IGameDownloadManager.Mock();
+        downloadManagerMock.FetchLibListAsync(Any<CancellationToken>()).Returns([]);
+        downloadManagerMock.FetchModListAsync(Any<CancellationToken>()).Returns(
+        [
+            CreateWebMod("Outdated", version: "2.0.0"),
+            CreateWebMod("UpToDate", version: "1.0.0", sha256: "shared-sha")
+        ]);
+        var notificationServiceMock = INotificationService.Mock();
+
+        var sut = CreateModManageService(
+            gameDownloadManager: downloadManagerMock,
+            fileSystemService: fileSystemServiceMock,
+            gameLocalService: LocalServiceWith(
+                ("/mods/Outdated.dll", outdated),
+                ("/mods/UpToDate.dll", upToDate)),
+            notificationService: notificationServiceMock);
+
+        await sut.InitializeModsAsync();
+        await sut.UpdateAllModsAsync();
+
+        downloadManagerMock.DownloadModAsync(Any<ModDto>(), Any<CancellationToken>()).WasCalled(Times.Once);
+    }
+
+    [Test]
+    public async Task UpdateAllModsAsync_WhenNoOutdatedMods_DoesNotDownload()
+    {
+        var upToDate = CreateInstalledMod();
+        upToDate.SHA256 = "shared-sha";
+
+        var downloadManagerMock = IGameDownloadManager.Mock();
+        downloadManagerMock.FetchLibListAsync(Any<CancellationToken>()).Returns([]);
+        downloadManagerMock.FetchModListAsync(Any<CancellationToken>()).Returns(
+        [
+            CreateWebMod(sha256: "shared-sha")
+        ]);
+
+        var sut = CreateModManageService(
+            gameDownloadManager: downloadManagerMock,
+            gameLocalService: LocalServiceWith((TestModFilePath, upToDate)));
+
+        await sut.InitializeModsAsync();
+        await sut.UpdateAllModsAsync();
+
+        downloadManagerMock.DownloadModAsync(Any<ModDto>(), Any<CancellationToken>()).WasCalled(Times.Never);
+    }
+
+    [Test]
     public async Task UpdateModAsync_WhenDownloadFails_NotifiesError()
     {
         var mod = CreateInstalledMod();

--- a/tests/Euterpe.Tests/Core/Services/ModManageService/ModManageServiceTest.Update.cs
+++ b/tests/Euterpe.Tests/Core/Services/ModManageService/ModManageServiceTest.Update.cs
@@ -81,7 +81,9 @@ public sealed partial class ModManageServiceTest
         await sut.InitializeModsAsync();
         await sut.UpdateAllModsAsync();
 
-        downloadManagerMock.DownloadModAsync(Any<ModDto>(), Any<CancellationToken>()).WasCalled(Times.Once);
+        using var _ = Assert.Multiple();
+        downloadManagerMock.DownloadModAsync(outdated, Any<CancellationToken>()).WasCalled(Times.Once);
+        downloadManagerMock.DownloadModAsync(upToDate, Any<CancellationToken>()).WasCalled(Times.Never);
     }
 
     [Test]


### PR DESCRIPTION
Adds the app-side deep link handlers the in-game mod raises at startup.

## Handlers

- `euterpe://mod/update/{modName}` — update a single installed mod (no-op with a log if the mod is unknown or not installed).
- `euterpe://mod/update` — update **all** outdated mods. New `IModManageService.UpdateAllModsAsync()` iterates the source cache for `ModState.Outdated` entries and updates each.
- `euterpe://chart/convert` — **placeholder only**. Routes cleanly (no longer falls through to the "unknown action" warning) and logs at info level; the actual legacy-chart conversion is intentionally not implemented yet.

## Notes

- `mod/update` (no trailing segment) vs `mod/update/{name}` are distinguished by list-pattern matching on the path segments, mirroring the existing install/uninstall handlers.
- Matching stays keyed by mod `Name` (case-sensitive), consistent with the rest of the deep link surface.

## Tests

- `ModManageServiceTest.Update`: `UpdateAllModsAsync` updates only outdated mods / no-ops when none are outdated.
- `DeepLinkServiceTest`: mod update-all dispatch, named update (installed / not-installed), chart convert placeholder logs without warning, unknown chart path warns.
- Full suite green (Euterpe.Tests 499 passed / 22 skipped, Headless 86 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)