### PR TITLE
Chart library follow-up: sort field localization, dedup, tests and rules

### DIFF
--- a/.claude/rules/csharp.md
+++ b/.claude/rules/csharp.md
@@ -5,6 +5,11 @@
 - Design the change, don't just complete the feature: a working implementation that leaves tech debt is not acceptable. If every viable approach leaves debt, the module itself is due for a redesign — surface that instead of bolting on.
 - Build along the known extension axes; this app already paid for assuming a single game (the `[PerGame]`/game-scope rework when multi-game support arrived). Ask "what varies when the next game/variant arrives" before hardcoding, and keep game-specific state and services game-scoped.
 
+## Language & APIs
+
+- Use the newest C# syntax and BCL APIs the repo's `LangVersion`/TFM allows (`field` keyword, `extension` members, collection expressions, span/`IFormatProvider` overloads) — never an older equivalent out of habit; the newer API is usually the better-optimized one.
+- When several APIs solve the same problem, pick the best-performing one for the concrete situation (allocations, lookup cost, parse overloads) — deliberately, not first-that-works.
+
 ## Naming & comments
 
 - Method and variable names must be self-explanatory; if a name needs a comment to be understood, rename it (e.g. `PlayingFolderName`, not `CurrentlyPlaying` + a comment).
@@ -33,12 +38,20 @@
 - No redundant wrapper services or pass-through methods: put the method on the existing domain service and make the real method public.
 - File/IO primitives go through `IFileSystemService` (`Try*` pattern); never raw `Directory`/`File` calls with ad-hoc try/catch in services.
 
+## Localization
+
+- During development add the neutral `.resx` plus `zh-Hans`/`zh-Hant` only — those are the locales the user can read and test with, and keys may still churn while the feature settles. The remaining locales get batch-translated once the feature is final.
+- Keys are `Name_Action_State` segments, scoped by where the text belongs:
+  - Page/panel-scoped view text: `<PanelName>_<Element>` (`ChartManage_SortBy`, `Setting_Title_Language`).
+  - Self-identifying concepts, especially enum members: `<TypeName>_<Member>` (`ChartDifficulty_Easy`, `ChartSortField_MapCount`, `ModFilterType_All`) — never borrow another feature's key because the value happens to match today.
+  - Code-side messages in `Interaction`: `<Kind>_Content_<Domain>_<Action>_<State>` (`Notification_Content_Chart_UpdateAll_Success`, `MessageBox_Content_SetPathEnvironment_Windows`).
+- Keep `.resx` data entries alphabetically ordered — merge new keys into place, never append at the end.
+
 ## Misc
 
 - Deduplicate shared one-liners into a single home (e.g. `ChartFiles.MapName`), even tiny ones.
 - Before writing anything by hand, check the packages already referenced (`Directory.Packages.props`) for an existing facility — especially the easily-forgotten ones: CommunityToolkit.Mvvm's `[NotifyPropertyChangedFor]` for dependent properties instead of manually raising `OnPropertyChanged`, R3 `Observable`s for event wiring/composition instead of manual event handlers.
 - Prefer an existing library over hand-rolling, but verify its actual behavior (decompile if needed) before adopting or rejecting it.
-- Localized strings: during development add the neutral `.resx` plus `zh-Hans`/`zh-Hant` only — those are the locales the user can read and test with, and keys may still churn while the feature settles. The remaining locales get batch-translated once the feature is final.
 - Logging via ZLogger interpolation (`Logger.ZLogInformation($"...")`).
 - DI: `public required T Name { get; init; }` properties inside `#region Injections`.
 - `.cs` files end with exactly one trailing newline (`insert_final_newline` applies to `[*.cs]` only).

--- a/src/Euterpe.Core/Extensions/SemVersionExtensions.cs
+++ b/src/Euterpe.Core/Extensions/SemVersionExtensions.cs
@@ -1,0 +1,10 @@
+namespace Euterpe.Core.Extensions;
+
+public static class SemVersionExtensions
+{
+    extension(string version)
+    {
+        public int ComparePrecedenceTo(string other) =>
+            SemVersion.Parse(version).ComparePrecedenceTo(SemVersion.Parse(other));
+    }
+}

--- a/src/Euterpe.Core/Services/ModManageService/ModManageService.Import.cs
+++ b/src/Euterpe.Core/Services/ModManageService/ModManageService.Import.cs
@@ -51,7 +51,7 @@ internal sealed partial class ModManageService
         var cached = _sourceCache.Lookup(mod.Name).ValueOrDefault();
         var installed = cached is { IsLocal: true } ? cached : null;
 
-        if (installed is not null && CompareModVersions(mod.LocalVersion, installed.LocalVersion) <= 0)
+        if (installed is not null && mod.LocalVersion.ComparePrecedenceTo(installed.LocalVersion) <= 0)
         {
             Logger.ZLogInformation($"Skipped import of {mod.Name}: version {installed.LocalVersion} already installed");
             NotificationService.WarningLight(Notification_Content_Mod_Import_Duplicated, mod.Name);

--- a/src/Euterpe.Core/Services/ModManageService/ModManageService.ModLoading.cs
+++ b/src/Euterpe.Core/Services/ModManageService/ModManageService.ModLoading.cs
@@ -72,7 +72,7 @@ internal sealed partial class ModManageService
             return ModState.Incompatible;
         }
 
-        return CompareModVersions(localMod.LocalVersion, webMod.Version) switch
+        return localMod.LocalVersion.ComparePrecedenceTo(webMod.Version) switch
         {
             < 0 => ModState.Outdated,
             > 0 => ModState.Newer,
@@ -80,9 +80,6 @@ internal sealed partial class ModManageService
             _ => ModState.Normal
         };
     }
-
-    private static int CompareModVersions(string left, string right) =>
-        SemVersion.Parse(left).ComparePrecedenceTo(SemVersion.Parse(right));
 
     private void CheckConfigFile(ModDto localMod)
     {

--- a/src/Euterpe.Localization/XAML/XAML.de.resx
+++ b/src/Euterpe.Localization/XAML/XAML.de.resx
@@ -73,6 +73,81 @@
   <data name="ChartDifficulty_Master" xml:space="preserve">
     <value>Master</value>
   </data>
+  <data name="ChartManage_Bpm" xml:space="preserve">
+    <value>BPM</value>
+  </data>
+  <data name="ChartManage_Delete" xml:space="preserve">
+    <value>Löschen</value>
+  </data>
+  <data name="ChartManage_Descending" xml:space="preserve">
+    <value>Absteigend</value>
+  </data>
+  <data name="ChartManage_Filter_Difficulty" xml:space="preserve">
+    <value>Schwierigkeit</value>
+  </data>
+  <data name="ChartManage_Filter_HasVideo" xml:space="preserve">
+    <value>Mit Video</value>
+  </data>
+  <data name="ChartManage_Filter_StreamerSafe" xml:space="preserve">
+    <value>Streamer-sicher</value>
+  </data>
+  <data name="ChartManage_GetCharts_Description" xml:space="preserve">
+    <value>Charts im Web durchsuchen &amp; herunterladen</value>
+  </data>
+  <data name="ChartManage_GetCharts_Title" xml:space="preserve">
+    <value>Charts holen</value>
+  </data>
+  <data name="ChartManage_MigrateMdm" xml:space="preserve">
+    <value>MDM-Charts migrieren</value>
+  </data>
+  <data name="ChartManage_Rating" xml:space="preserve">
+    <value>Bewertung</value>
+  </data>
+  <data name="ChartManage_Reset" xml:space="preserve">
+    <value>Zurücksetzen</value>
+  </data>
+  <data name="ChartManage_SortBy" xml:space="preserve">
+    <value>Sortieren nach</value>
+  </data>
+  <data name="ChartManage_Tag_Video" xml:space="preserve">
+    <value>Video</value>
+  </data>
+  <data name="ChartManage_UpdateAll" xml:space="preserve">
+    <value>Alle Charts aktualisieren</value>
+  </data>
+  <data name="ChartManage_UploadedBy" xml:space="preserve">
+    <value>von {0}</value>
+  </data>
+  <data name="ChartSortField_Author" xml:space="preserve">
+    <value>Autor</value>
+  </data>
+  <data name="ChartSortField_Bpm" xml:space="preserve">
+    <value>BPM</value>
+  </data>
+  <data name="ChartSortField_DateAdded" xml:space="preserve">
+    <value>Hinzugefügt am</value>
+  </data>
+  <data name="ChartSortField_DateUpdated" xml:space="preserve">
+    <value>Aktualisiert am</value>
+  </data>
+  <data name="ChartSortField_MapCount" xml:space="preserve">
+    <value>Maps</value>
+  </data>
+  <data name="ChartSortField_Name" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="ChartSortField_Rating" xml:space="preserve">
+    <value>Bewertung</value>
+  </data>
+  <data name="ChartSortField_Size" xml:space="preserve">
+    <value>Dateigröße</value>
+  </data>
+  <data name="ChartSource_Offline" xml:space="preserve">
+    <value>Offline</value>
+  </data>
+  <data name="ChartSource_Online" xml:space="preserve">
+    <value>Online</value>
+  </data>
   <data name="Contributor_Artist" xml:space="preserve">
     <value>Künstler</value>
   </data>
@@ -489,71 +564,5 @@
   </data>
   <data name="Wizard_Title_Welcome" xml:space="preserve">
     <value>Willkommen bei Euterpe</value>
-  </data>
-  <data name="ChartManage_Bpm" xml:space="preserve">
-    <value>BPM</value>
-  </data>
-  <data name="ChartManage_Delete" xml:space="preserve">
-    <value>Löschen</value>
-  </data>
-  <data name="ChartManage_Descending" xml:space="preserve">
-    <value>Absteigend</value>
-  </data>
-  <data name="ChartManage_Filter_Difficulty" xml:space="preserve">
-    <value>Schwierigkeit</value>
-  </data>
-  <data name="ChartManage_Filter_HasVideo" xml:space="preserve">
-    <value>Mit Video</value>
-  </data>
-  <data name="ChartManage_Filter_StreamerSafe" xml:space="preserve">
-    <value>Streamer-sicher</value>
-  </data>
-  <data name="ChartManage_GetCharts_Description" xml:space="preserve">
-    <value>Charts im Web durchsuchen &amp; herunterladen</value>
-  </data>
-  <data name="ChartManage_GetCharts_Title" xml:space="preserve">
-    <value>Charts holen</value>
-  </data>
-  <data name="ChartManage_Rating" xml:space="preserve">
-    <value>Bewertung</value>
-  </data>
-  <data name="ChartManage_Reset" xml:space="preserve">
-    <value>Zurücksetzen</value>
-  </data>
-  <data name="ChartManage_Sort_DateAdded" xml:space="preserve">
-    <value>Hinzugefügt am</value>
-  </data>
-  <data name="ChartManage_Sort_DateUpdated" xml:space="preserve">
-    <value>Aktualisiert am</value>
-  </data>
-  <data name="ChartManage_Sort_Maps" xml:space="preserve">
-    <value>Maps</value>
-  </data>
-  <data name="ChartManage_Sort_Name" xml:space="preserve">
-    <value>Name</value>
-  </data>
-  <data name="ChartManage_SortBy" xml:space="preserve">
-    <value>Sortieren nach</value>
-  </data>
-  <data name="ChartManage_Tag_Video" xml:space="preserve">
-    <value>Video</value>
-  </data>
-  <data name="ChartManage_UploadedBy" xml:space="preserve">
-    <value>von {0}</value>
-  </data>
-  <data name="ChartSource_Offline" xml:space="preserve">
-    <value>Offline</value>
-  </data>
-  <data name="ChartSource_Online" xml:space="preserve">
-    <value>Online</value>
-  </data>
-  <data name="ChartManage_UpdateAll" xml:space="preserve">
-    <value>Alle Charts aktualisieren</value>
-  </data>
-  <data name="ChartManage_MigrateMdm" xml:space="preserve">
-    <value>MDM-Charts migrieren</value>
-  </data>
-  <data name="ChartManage_Sort_FileSize" xml:space="preserve">
-    <value>Dateigröße</value>
   </data>
 </root>

--- a/src/Euterpe.Localization/XAML/XAML.es.resx
+++ b/src/Euterpe.Localization/XAML/XAML.es.resx
@@ -73,6 +73,81 @@
   <data name="ChartDifficulty_Master" xml:space="preserve">
     <value>Maestro</value>
   </data>
+  <data name="ChartManage_Bpm" xml:space="preserve">
+    <value>BPM</value>
+  </data>
+  <data name="ChartManage_Delete" xml:space="preserve">
+    <value>Eliminar</value>
+  </data>
+  <data name="ChartManage_Descending" xml:space="preserve">
+    <value>Descendente</value>
+  </data>
+  <data name="ChartManage_Filter_Difficulty" xml:space="preserve">
+    <value>Dificultad</value>
+  </data>
+  <data name="ChartManage_Filter_HasVideo" xml:space="preserve">
+    <value>Con vídeo</value>
+  </data>
+  <data name="ChartManage_Filter_StreamerSafe" xml:space="preserve">
+    <value>Apto para streaming</value>
+  </data>
+  <data name="ChartManage_GetCharts_Description" xml:space="preserve">
+    <value>Explora y descarga charts en la web</value>
+  </data>
+  <data name="ChartManage_GetCharts_Title" xml:space="preserve">
+    <value>Obtener charts</value>
+  </data>
+  <data name="ChartManage_MigrateMdm" xml:space="preserve">
+    <value>Migrar charts de MDM</value>
+  </data>
+  <data name="ChartManage_Rating" xml:space="preserve">
+    <value>Nivel</value>
+  </data>
+  <data name="ChartManage_Reset" xml:space="preserve">
+    <value>Restablecer</value>
+  </data>
+  <data name="ChartManage_SortBy" xml:space="preserve">
+    <value>Ordenar por</value>
+  </data>
+  <data name="ChartManage_Tag_Video" xml:space="preserve">
+    <value>Vídeo</value>
+  </data>
+  <data name="ChartManage_UpdateAll" xml:space="preserve">
+    <value>Actualizar todos los charts</value>
+  </data>
+  <data name="ChartManage_UploadedBy" xml:space="preserve">
+    <value>por {0}</value>
+  </data>
+  <data name="ChartSortField_Author" xml:space="preserve">
+    <value>Autor</value>
+  </data>
+  <data name="ChartSortField_Bpm" xml:space="preserve">
+    <value>BPM</value>
+  </data>
+  <data name="ChartSortField_DateAdded" xml:space="preserve">
+    <value>Fecha de adición</value>
+  </data>
+  <data name="ChartSortField_DateUpdated" xml:space="preserve">
+    <value>Fecha de actualización</value>
+  </data>
+  <data name="ChartSortField_MapCount" xml:space="preserve">
+    <value>Mapas</value>
+  </data>
+  <data name="ChartSortField_Name" xml:space="preserve">
+    <value>Nombre</value>
+  </data>
+  <data name="ChartSortField_Rating" xml:space="preserve">
+    <value>Nivel</value>
+  </data>
+  <data name="ChartSortField_Size" xml:space="preserve">
+    <value>Tamaño de archivo</value>
+  </data>
+  <data name="ChartSource_Offline" xml:space="preserve">
+    <value>Offline</value>
+  </data>
+  <data name="ChartSource_Online" xml:space="preserve">
+    <value>Online</value>
+  </data>
   <data name="Contributor_Artist" xml:space="preserve">
     <value>Artista</value>
   </data>
@@ -489,71 +564,5 @@
   </data>
   <data name="Wizard_Title_Welcome" xml:space="preserve">
     <value>Bienvenido a Euterpe</value>
-  </data>
-  <data name="ChartManage_Bpm" xml:space="preserve">
-    <value>BPM</value>
-  </data>
-  <data name="ChartManage_Delete" xml:space="preserve">
-    <value>Eliminar</value>
-  </data>
-  <data name="ChartManage_Descending" xml:space="preserve">
-    <value>Descendente</value>
-  </data>
-  <data name="ChartManage_Filter_Difficulty" xml:space="preserve">
-    <value>Dificultad</value>
-  </data>
-  <data name="ChartManage_Filter_HasVideo" xml:space="preserve">
-    <value>Con vídeo</value>
-  </data>
-  <data name="ChartManage_Filter_StreamerSafe" xml:space="preserve">
-    <value>Apto para streaming</value>
-  </data>
-  <data name="ChartManage_GetCharts_Description" xml:space="preserve">
-    <value>Explora y descarga charts en la web</value>
-  </data>
-  <data name="ChartManage_GetCharts_Title" xml:space="preserve">
-    <value>Obtener charts</value>
-  </data>
-  <data name="ChartManage_Rating" xml:space="preserve">
-    <value>Nivel</value>
-  </data>
-  <data name="ChartManage_Reset" xml:space="preserve">
-    <value>Restablecer</value>
-  </data>
-  <data name="ChartManage_Sort_DateAdded" xml:space="preserve">
-    <value>Fecha de adición</value>
-  </data>
-  <data name="ChartManage_Sort_DateUpdated" xml:space="preserve">
-    <value>Fecha de actualización</value>
-  </data>
-  <data name="ChartManage_Sort_Maps" xml:space="preserve">
-    <value>Mapas</value>
-  </data>
-  <data name="ChartManage_Sort_Name" xml:space="preserve">
-    <value>Nombre</value>
-  </data>
-  <data name="ChartManage_SortBy" xml:space="preserve">
-    <value>Ordenar por</value>
-  </data>
-  <data name="ChartManage_Tag_Video" xml:space="preserve">
-    <value>Vídeo</value>
-  </data>
-  <data name="ChartManage_UploadedBy" xml:space="preserve">
-    <value>por {0}</value>
-  </data>
-  <data name="ChartSource_Offline" xml:space="preserve">
-    <value>Offline</value>
-  </data>
-  <data name="ChartSource_Online" xml:space="preserve">
-    <value>Online</value>
-  </data>
-  <data name="ChartManage_UpdateAll" xml:space="preserve">
-    <value>Actualizar todos los charts</value>
-  </data>
-  <data name="ChartManage_MigrateMdm" xml:space="preserve">
-    <value>Migrar charts de MDM</value>
-  </data>
-  <data name="ChartManage_Sort_FileSize" xml:space="preserve">
-    <value>Tamaño de archivo</value>
   </data>
 </root>

--- a/src/Euterpe.Localization/XAML/XAML.fr.resx
+++ b/src/Euterpe.Localization/XAML/XAML.fr.resx
@@ -73,6 +73,81 @@
   <data name="ChartDifficulty_Master" xml:space="preserve">
     <value>Master</value>
   </data>
+  <data name="ChartManage_Bpm" xml:space="preserve">
+    <value>BPM</value>
+  </data>
+  <data name="ChartManage_Delete" xml:space="preserve">
+    <value>Supprimer</value>
+  </data>
+  <data name="ChartManage_Descending" xml:space="preserve">
+    <value>Décroissant</value>
+  </data>
+  <data name="ChartManage_Filter_Difficulty" xml:space="preserve">
+    <value>Difficulté</value>
+  </data>
+  <data name="ChartManage_Filter_HasVideo" xml:space="preserve">
+    <value>Avec vidéo</value>
+  </data>
+  <data name="ChartManage_Filter_StreamerSafe" xml:space="preserve">
+    <value>Sûr pour le streaming</value>
+  </data>
+  <data name="ChartManage_GetCharts_Description" xml:space="preserve">
+    <value>Parcourir &amp; télécharger des charts sur le web</value>
+  </data>
+  <data name="ChartManage_GetCharts_Title" xml:space="preserve">
+    <value>Obtenir des charts</value>
+  </data>
+  <data name="ChartManage_MigrateMdm" xml:space="preserve">
+    <value>Migrer les charts MDM</value>
+  </data>
+  <data name="ChartManage_Rating" xml:space="preserve">
+    <value>Niveau</value>
+  </data>
+  <data name="ChartManage_Reset" xml:space="preserve">
+    <value>Réinitialiser</value>
+  </data>
+  <data name="ChartManage_SortBy" xml:space="preserve">
+    <value>Trier par</value>
+  </data>
+  <data name="ChartManage_Tag_Video" xml:space="preserve">
+    <value>Vidéo</value>
+  </data>
+  <data name="ChartManage_UpdateAll" xml:space="preserve">
+    <value>Mettre à jour tous les charts</value>
+  </data>
+  <data name="ChartManage_UploadedBy" xml:space="preserve">
+    <value>par {0}</value>
+  </data>
+  <data name="ChartSortField_Author" xml:space="preserve">
+    <value>Auteur</value>
+  </data>
+  <data name="ChartSortField_Bpm" xml:space="preserve">
+    <value>BPM</value>
+  </data>
+  <data name="ChartSortField_DateAdded" xml:space="preserve">
+    <value>Date d'ajout</value>
+  </data>
+  <data name="ChartSortField_DateUpdated" xml:space="preserve">
+    <value>Date de mise à jour</value>
+  </data>
+  <data name="ChartSortField_MapCount" xml:space="preserve">
+    <value>Maps</value>
+  </data>
+  <data name="ChartSortField_Name" xml:space="preserve">
+    <value>Nom</value>
+  </data>
+  <data name="ChartSortField_Rating" xml:space="preserve">
+    <value>Niveau</value>
+  </data>
+  <data name="ChartSortField_Size" xml:space="preserve">
+    <value>Taille de fichier</value>
+  </data>
+  <data name="ChartSource_Offline" xml:space="preserve">
+    <value>Offline</value>
+  </data>
+  <data name="ChartSource_Online" xml:space="preserve">
+    <value>Online</value>
+  </data>
   <data name="Contributor_Artist" xml:space="preserve">
     <value>Artiste</value>
   </data>
@@ -489,71 +564,5 @@
   </data>
   <data name="Wizard_Title_Welcome" xml:space="preserve">
     <value>Bienvenue sur Euterpe</value>
-  </data>
-  <data name="ChartManage_Bpm" xml:space="preserve">
-    <value>BPM</value>
-  </data>
-  <data name="ChartManage_Delete" xml:space="preserve">
-    <value>Supprimer</value>
-  </data>
-  <data name="ChartManage_Descending" xml:space="preserve">
-    <value>Décroissant</value>
-  </data>
-  <data name="ChartManage_Filter_Difficulty" xml:space="preserve">
-    <value>Difficulté</value>
-  </data>
-  <data name="ChartManage_Filter_HasVideo" xml:space="preserve">
-    <value>Avec vidéo</value>
-  </data>
-  <data name="ChartManage_Filter_StreamerSafe" xml:space="preserve">
-    <value>Sûr pour le streaming</value>
-  </data>
-  <data name="ChartManage_GetCharts_Description" xml:space="preserve">
-    <value>Parcourir &amp; télécharger des charts sur le web</value>
-  </data>
-  <data name="ChartManage_GetCharts_Title" xml:space="preserve">
-    <value>Obtenir des charts</value>
-  </data>
-  <data name="ChartManage_Rating" xml:space="preserve">
-    <value>Niveau</value>
-  </data>
-  <data name="ChartManage_Reset" xml:space="preserve">
-    <value>Réinitialiser</value>
-  </data>
-  <data name="ChartManage_Sort_DateAdded" xml:space="preserve">
-    <value>Date d'ajout</value>
-  </data>
-  <data name="ChartManage_Sort_DateUpdated" xml:space="preserve">
-    <value>Date de mise à jour</value>
-  </data>
-  <data name="ChartManage_Sort_Maps" xml:space="preserve">
-    <value>Maps</value>
-  </data>
-  <data name="ChartManage_Sort_Name" xml:space="preserve">
-    <value>Nom</value>
-  </data>
-  <data name="ChartManage_SortBy" xml:space="preserve">
-    <value>Trier par</value>
-  </data>
-  <data name="ChartManage_Tag_Video" xml:space="preserve">
-    <value>Vidéo</value>
-  </data>
-  <data name="ChartManage_UploadedBy" xml:space="preserve">
-    <value>par {0}</value>
-  </data>
-  <data name="ChartSource_Offline" xml:space="preserve">
-    <value>Offline</value>
-  </data>
-  <data name="ChartSource_Online" xml:space="preserve">
-    <value>Online</value>
-  </data>
-  <data name="ChartManage_UpdateAll" xml:space="preserve">
-    <value>Mettre à jour tous les charts</value>
-  </data>
-  <data name="ChartManage_MigrateMdm" xml:space="preserve">
-    <value>Migrer les charts MDM</value>
-  </data>
-  <data name="ChartManage_Sort_FileSize" xml:space="preserve">
-    <value>Taille de fichier</value>
   </data>
 </root>

--- a/src/Euterpe.Localization/XAML/XAML.hr.resx
+++ b/src/Euterpe.Localization/XAML/XAML.hr.resx
@@ -73,6 +73,81 @@
   <data name="ChartDifficulty_Master" xml:space="preserve">
     <value>Master</value>
   </data>
+  <data name="ChartManage_Bpm" xml:space="preserve">
+    <value>BPM</value>
+  </data>
+  <data name="ChartManage_Delete" xml:space="preserve">
+    <value>Izbriši</value>
+  </data>
+  <data name="ChartManage_Descending" xml:space="preserve">
+    <value>Silazno</value>
+  </data>
+  <data name="ChartManage_Filter_Difficulty" xml:space="preserve">
+    <value>Težina</value>
+  </data>
+  <data name="ChartManage_Filter_HasVideo" xml:space="preserve">
+    <value>Ima videozapis</value>
+  </data>
+  <data name="ChartManage_Filter_StreamerSafe" xml:space="preserve">
+    <value>Sigurno za streamanje</value>
+  </data>
+  <data name="ChartManage_GetCharts_Description" xml:space="preserve">
+    <value>Pregledaj i preuzmi chartove na webu</value>
+  </data>
+  <data name="ChartManage_GetCharts_Title" xml:space="preserve">
+    <value>Nabavi chartove</value>
+  </data>
+  <data name="ChartManage_MigrateMdm" xml:space="preserve">
+    <value>Migriraj MDM chartove</value>
+  </data>
+  <data name="ChartManage_Rating" xml:space="preserve">
+    <value>Razina</value>
+  </data>
+  <data name="ChartManage_Reset" xml:space="preserve">
+    <value>Poništi</value>
+  </data>
+  <data name="ChartManage_SortBy" xml:space="preserve">
+    <value>Razvrstaj po</value>
+  </data>
+  <data name="ChartManage_Tag_Video" xml:space="preserve">
+    <value>Videozapis</value>
+  </data>
+  <data name="ChartManage_UpdateAll" xml:space="preserve">
+    <value>Ažuriraj sve chartove</value>
+  </data>
+  <data name="ChartManage_UploadedBy" xml:space="preserve">
+    <value>autor {0}</value>
+  </data>
+  <data name="ChartSortField_Author" xml:space="preserve">
+    <value>Autor</value>
+  </data>
+  <data name="ChartSortField_Bpm" xml:space="preserve">
+    <value>BPM</value>
+  </data>
+  <data name="ChartSortField_DateAdded" xml:space="preserve">
+    <value>Datum dodavanja</value>
+  </data>
+  <data name="ChartSortField_DateUpdated" xml:space="preserve">
+    <value>Datum ažuriranja</value>
+  </data>
+  <data name="ChartSortField_MapCount" xml:space="preserve">
+    <value>Mape</value>
+  </data>
+  <data name="ChartSortField_Name" xml:space="preserve">
+    <value>Naziv</value>
+  </data>
+  <data name="ChartSortField_Rating" xml:space="preserve">
+    <value>Razina</value>
+  </data>
+  <data name="ChartSortField_Size" xml:space="preserve">
+    <value>Veličina datoteke</value>
+  </data>
+  <data name="ChartSource_Offline" xml:space="preserve">
+    <value>Offline</value>
+  </data>
+  <data name="ChartSource_Online" xml:space="preserve">
+    <value>Online</value>
+  </data>
   <data name="Contributor_Artist" xml:space="preserve">
     <value>Umjetnik</value>
   </data>
@@ -489,71 +564,5 @@
   </data>
   <data name="Wizard_Title_Welcome" xml:space="preserve">
     <value>Dobrodošli u Euterpe</value>
-  </data>
-  <data name="ChartManage_Bpm" xml:space="preserve">
-    <value>BPM</value>
-  </data>
-  <data name="ChartManage_Delete" xml:space="preserve">
-    <value>Izbriši</value>
-  </data>
-  <data name="ChartManage_Descending" xml:space="preserve">
-    <value>Silazno</value>
-  </data>
-  <data name="ChartManage_Filter_Difficulty" xml:space="preserve">
-    <value>Težina</value>
-  </data>
-  <data name="ChartManage_Filter_HasVideo" xml:space="preserve">
-    <value>Ima videozapis</value>
-  </data>
-  <data name="ChartManage_Filter_StreamerSafe" xml:space="preserve">
-    <value>Sigurno za streamanje</value>
-  </data>
-  <data name="ChartManage_GetCharts_Description" xml:space="preserve">
-    <value>Pregledaj i preuzmi chartove na webu</value>
-  </data>
-  <data name="ChartManage_GetCharts_Title" xml:space="preserve">
-    <value>Nabavi chartove</value>
-  </data>
-  <data name="ChartManage_Rating" xml:space="preserve">
-    <value>Razina</value>
-  </data>
-  <data name="ChartManage_Reset" xml:space="preserve">
-    <value>Poništi</value>
-  </data>
-  <data name="ChartManage_Sort_DateAdded" xml:space="preserve">
-    <value>Datum dodavanja</value>
-  </data>
-  <data name="ChartManage_Sort_DateUpdated" xml:space="preserve">
-    <value>Datum ažuriranja</value>
-  </data>
-  <data name="ChartManage_Sort_Maps" xml:space="preserve">
-    <value>Mape</value>
-  </data>
-  <data name="ChartManage_Sort_Name" xml:space="preserve">
-    <value>Naziv</value>
-  </data>
-  <data name="ChartManage_SortBy" xml:space="preserve">
-    <value>Razvrstaj po</value>
-  </data>
-  <data name="ChartManage_Tag_Video" xml:space="preserve">
-    <value>Videozapis</value>
-  </data>
-  <data name="ChartManage_UploadedBy" xml:space="preserve">
-    <value>autor {0}</value>
-  </data>
-  <data name="ChartSource_Offline" xml:space="preserve">
-    <value>Offline</value>
-  </data>
-  <data name="ChartSource_Online" xml:space="preserve">
-    <value>Online</value>
-  </data>
-  <data name="ChartManage_UpdateAll" xml:space="preserve">
-    <value>Ažuriraj sve chartove</value>
-  </data>
-  <data name="ChartManage_MigrateMdm" xml:space="preserve">
-    <value>Migriraj MDM chartove</value>
-  </data>
-  <data name="ChartManage_Sort_FileSize" xml:space="preserve">
-    <value>Veličina datoteke</value>
   </data>
 </root>

--- a/src/Euterpe.Localization/XAML/XAML.hu.resx
+++ b/src/Euterpe.Localization/XAML/XAML.hu.resx
@@ -73,6 +73,81 @@
   <data name="ChartDifficulty_Master" xml:space="preserve">
     <value>Mester</value>
   </data>
+  <data name="ChartManage_Bpm" xml:space="preserve">
+    <value>BPM</value>
+  </data>
+  <data name="ChartManage_Delete" xml:space="preserve">
+    <value>Törlés</value>
+  </data>
+  <data name="ChartManage_Descending" xml:space="preserve">
+    <value>Csökkenő</value>
+  </data>
+  <data name="ChartManage_Filter_Difficulty" xml:space="preserve">
+    <value>Nehézség</value>
+  </data>
+  <data name="ChartManage_Filter_HasVideo" xml:space="preserve">
+    <value>Van videó</value>
+  </data>
+  <data name="ChartManage_Filter_StreamerSafe" xml:space="preserve">
+    <value>Streamelhető</value>
+  </data>
+  <data name="ChartManage_GetCharts_Description" xml:space="preserve">
+    <value>Chartek böngészése &amp; letöltése a weben</value>
+  </data>
+  <data name="ChartManage_GetCharts_Title" xml:space="preserve">
+    <value>Chartek beszerzése</value>
+  </data>
+  <data name="ChartManage_MigrateMdm" xml:space="preserve">
+    <value>MDM chartek migrálása</value>
+  </data>
+  <data name="ChartManage_Rating" xml:space="preserve">
+    <value>Szint</value>
+  </data>
+  <data name="ChartManage_Reset" xml:space="preserve">
+    <value>Visszaállítás</value>
+  </data>
+  <data name="ChartManage_SortBy" xml:space="preserve">
+    <value>Rendezés</value>
+  </data>
+  <data name="ChartManage_Tag_Video" xml:space="preserve">
+    <value>Videó</value>
+  </data>
+  <data name="ChartManage_UpdateAll" xml:space="preserve">
+    <value>Összes chart frissítése</value>
+  </data>
+  <data name="ChartManage_UploadedBy" xml:space="preserve">
+    <value>készítette: {0}</value>
+  </data>
+  <data name="ChartSortField_Author" xml:space="preserve">
+    <value>Szerző</value>
+  </data>
+  <data name="ChartSortField_Bpm" xml:space="preserve">
+    <value>BPM</value>
+  </data>
+  <data name="ChartSortField_DateAdded" xml:space="preserve">
+    <value>Hozzáadás dátuma</value>
+  </data>
+  <data name="ChartSortField_DateUpdated" xml:space="preserve">
+    <value>Frissítés dátuma</value>
+  </data>
+  <data name="ChartSortField_MapCount" xml:space="preserve">
+    <value>Mapek</value>
+  </data>
+  <data name="ChartSortField_Name" xml:space="preserve">
+    <value>Név</value>
+  </data>
+  <data name="ChartSortField_Rating" xml:space="preserve">
+    <value>Szint</value>
+  </data>
+  <data name="ChartSortField_Size" xml:space="preserve">
+    <value>Fájlméret</value>
+  </data>
+  <data name="ChartSource_Offline" xml:space="preserve">
+    <value>Offline</value>
+  </data>
+  <data name="ChartSource_Online" xml:space="preserve">
+    <value>Online</value>
+  </data>
   <data name="Contributor_Artist" xml:space="preserve">
     <value>Művész</value>
   </data>
@@ -489,71 +564,5 @@
   </data>
   <data name="Wizard_Title_Welcome" xml:space="preserve">
     <value>Üdvözöl az Euterpe</value>
-  </data>
-  <data name="ChartManage_Bpm" xml:space="preserve">
-    <value>BPM</value>
-  </data>
-  <data name="ChartManage_Delete" xml:space="preserve">
-    <value>Törlés</value>
-  </data>
-  <data name="ChartManage_Descending" xml:space="preserve">
-    <value>Csökkenő</value>
-  </data>
-  <data name="ChartManage_Filter_Difficulty" xml:space="preserve">
-    <value>Nehézség</value>
-  </data>
-  <data name="ChartManage_Filter_HasVideo" xml:space="preserve">
-    <value>Van videó</value>
-  </data>
-  <data name="ChartManage_Filter_StreamerSafe" xml:space="preserve">
-    <value>Streamelhető</value>
-  </data>
-  <data name="ChartManage_GetCharts_Description" xml:space="preserve">
-    <value>Chartek böngészése &amp; letöltése a weben</value>
-  </data>
-  <data name="ChartManage_GetCharts_Title" xml:space="preserve">
-    <value>Chartek beszerzése</value>
-  </data>
-  <data name="ChartManage_Rating" xml:space="preserve">
-    <value>Szint</value>
-  </data>
-  <data name="ChartManage_Reset" xml:space="preserve">
-    <value>Visszaállítás</value>
-  </data>
-  <data name="ChartManage_Sort_DateAdded" xml:space="preserve">
-    <value>Hozzáadás dátuma</value>
-  </data>
-  <data name="ChartManage_Sort_DateUpdated" xml:space="preserve">
-    <value>Frissítés dátuma</value>
-  </data>
-  <data name="ChartManage_Sort_Maps" xml:space="preserve">
-    <value>Mapek</value>
-  </data>
-  <data name="ChartManage_Sort_Name" xml:space="preserve">
-    <value>Név</value>
-  </data>
-  <data name="ChartManage_SortBy" xml:space="preserve">
-    <value>Rendezés</value>
-  </data>
-  <data name="ChartManage_Tag_Video" xml:space="preserve">
-    <value>Videó</value>
-  </data>
-  <data name="ChartManage_UploadedBy" xml:space="preserve">
-    <value>készítette: {0}</value>
-  </data>
-  <data name="ChartSource_Offline" xml:space="preserve">
-    <value>Offline</value>
-  </data>
-  <data name="ChartSource_Online" xml:space="preserve">
-    <value>Online</value>
-  </data>
-  <data name="ChartManage_UpdateAll" xml:space="preserve">
-    <value>Összes chart frissítése</value>
-  </data>
-  <data name="ChartManage_MigrateMdm" xml:space="preserve">
-    <value>MDM chartek migrálása</value>
-  </data>
-  <data name="ChartManage_Sort_FileSize" xml:space="preserve">
-    <value>Fájlméret</value>
   </data>
 </root>

--- a/src/Euterpe.Localization/XAML/XAML.id.resx
+++ b/src/Euterpe.Localization/XAML/XAML.id.resx
@@ -73,6 +73,81 @@
   <data name="ChartDifficulty_Master" xml:space="preserve">
     <value>Master</value>
   </data>
+  <data name="ChartManage_Bpm" xml:space="preserve">
+    <value>BPM</value>
+  </data>
+  <data name="ChartManage_Delete" xml:space="preserve">
+    <value>Hapus</value>
+  </data>
+  <data name="ChartManage_Descending" xml:space="preserve">
+    <value>Menurun</value>
+  </data>
+  <data name="ChartManage_Filter_Difficulty" xml:space="preserve">
+    <value>Kesulitan</value>
+  </data>
+  <data name="ChartManage_Filter_HasVideo" xml:space="preserve">
+    <value>Ada Video</value>
+  </data>
+  <data name="ChartManage_Filter_StreamerSafe" xml:space="preserve">
+    <value>Aman untuk Streaming</value>
+  </data>
+  <data name="ChartManage_GetCharts_Description" xml:space="preserve">
+    <value>Jelajahi &amp; unduh chart di web</value>
+  </data>
+  <data name="ChartManage_GetCharts_Title" xml:space="preserve">
+    <value>Dapatkan Chart</value>
+  </data>
+  <data name="ChartManage_MigrateMdm" xml:space="preserve">
+    <value>Migrasikan Chart MDM</value>
+  </data>
+  <data name="ChartManage_Rating" xml:space="preserve">
+    <value>Tingkat</value>
+  </data>
+  <data name="ChartManage_Reset" xml:space="preserve">
+    <value>Atur Ulang</value>
+  </data>
+  <data name="ChartManage_SortBy" xml:space="preserve">
+    <value>Urutkan Berdasarkan</value>
+  </data>
+  <data name="ChartManage_Tag_Video" xml:space="preserve">
+    <value>Video</value>
+  </data>
+  <data name="ChartManage_UpdateAll" xml:space="preserve">
+    <value>Perbarui Semua Chart</value>
+  </data>
+  <data name="ChartManage_UploadedBy" xml:space="preserve">
+    <value>oleh {0}</value>
+  </data>
+  <data name="ChartSortField_Author" xml:space="preserve">
+    <value>Penulis</value>
+  </data>
+  <data name="ChartSortField_Bpm" xml:space="preserve">
+    <value>BPM</value>
+  </data>
+  <data name="ChartSortField_DateAdded" xml:space="preserve">
+    <value>Tanggal Ditambahkan</value>
+  </data>
+  <data name="ChartSortField_DateUpdated" xml:space="preserve">
+    <value>Tanggal Diperbarui</value>
+  </data>
+  <data name="ChartSortField_MapCount" xml:space="preserve">
+    <value>Jumlah Map</value>
+  </data>
+  <data name="ChartSortField_Name" xml:space="preserve">
+    <value>Nama</value>
+  </data>
+  <data name="ChartSortField_Rating" xml:space="preserve">
+    <value>Tingkat</value>
+  </data>
+  <data name="ChartSortField_Size" xml:space="preserve">
+    <value>Ukuran File</value>
+  </data>
+  <data name="ChartSource_Offline" xml:space="preserve">
+    <value>Offline</value>
+  </data>
+  <data name="ChartSource_Online" xml:space="preserve">
+    <value>Online</value>
+  </data>
   <data name="Contributor_Artist" xml:space="preserve">
     <value>Seniman</value>
   </data>
@@ -489,71 +564,5 @@
   </data>
   <data name="Wizard_Title_Welcome" xml:space="preserve">
     <value>Selamat Datang di Euterpe</value>
-  </data>
-  <data name="ChartManage_Bpm" xml:space="preserve">
-    <value>BPM</value>
-  </data>
-  <data name="ChartManage_Delete" xml:space="preserve">
-    <value>Hapus</value>
-  </data>
-  <data name="ChartManage_Descending" xml:space="preserve">
-    <value>Menurun</value>
-  </data>
-  <data name="ChartManage_Filter_Difficulty" xml:space="preserve">
-    <value>Kesulitan</value>
-  </data>
-  <data name="ChartManage_Filter_HasVideo" xml:space="preserve">
-    <value>Ada Video</value>
-  </data>
-  <data name="ChartManage_Filter_StreamerSafe" xml:space="preserve">
-    <value>Aman untuk Streaming</value>
-  </data>
-  <data name="ChartManage_GetCharts_Description" xml:space="preserve">
-    <value>Jelajahi &amp; unduh chart di web</value>
-  </data>
-  <data name="ChartManage_GetCharts_Title" xml:space="preserve">
-    <value>Dapatkan Chart</value>
-  </data>
-  <data name="ChartManage_Rating" xml:space="preserve">
-    <value>Tingkat</value>
-  </data>
-  <data name="ChartManage_Reset" xml:space="preserve">
-    <value>Atur Ulang</value>
-  </data>
-  <data name="ChartManage_Sort_DateAdded" xml:space="preserve">
-    <value>Tanggal Ditambahkan</value>
-  </data>
-  <data name="ChartManage_Sort_DateUpdated" xml:space="preserve">
-    <value>Tanggal Diperbarui</value>
-  </data>
-  <data name="ChartManage_Sort_Maps" xml:space="preserve">
-    <value>Jumlah Map</value>
-  </data>
-  <data name="ChartManage_Sort_Name" xml:space="preserve">
-    <value>Nama</value>
-  </data>
-  <data name="ChartManage_SortBy" xml:space="preserve">
-    <value>Urutkan Berdasarkan</value>
-  </data>
-  <data name="ChartManage_Tag_Video" xml:space="preserve">
-    <value>Video</value>
-  </data>
-  <data name="ChartManage_UploadedBy" xml:space="preserve">
-    <value>oleh {0}</value>
-  </data>
-  <data name="ChartSource_Offline" xml:space="preserve">
-    <value>Offline</value>
-  </data>
-  <data name="ChartSource_Online" xml:space="preserve">
-    <value>Online</value>
-  </data>
-  <data name="ChartManage_UpdateAll" xml:space="preserve">
-    <value>Perbarui Semua Chart</value>
-  </data>
-  <data name="ChartManage_MigrateMdm" xml:space="preserve">
-    <value>Migrasikan Chart MDM</value>
-  </data>
-  <data name="ChartManage_Sort_FileSize" xml:space="preserve">
-    <value>Ukuran File</value>
   </data>
 </root>

--- a/src/Euterpe.Localization/XAML/XAML.ja.resx
+++ b/src/Euterpe.Localization/XAML/XAML.ja.resx
@@ -73,6 +73,81 @@
   <data name="ChartDifficulty_Master" xml:space="preserve">
     <value>達人</value>
   </data>
+  <data name="ChartManage_Bpm" xml:space="preserve">
+    <value>BPM</value>
+  </data>
+  <data name="ChartManage_Delete" xml:space="preserve">
+    <value>削除</value>
+  </data>
+  <data name="ChartManage_Descending" xml:space="preserve">
+    <value>降順</value>
+  </data>
+  <data name="ChartManage_Filter_Difficulty" xml:space="preserve">
+    <value>難易度</value>
+  </data>
+  <data name="ChartManage_Filter_HasVideo" xml:space="preserve">
+    <value>動画あり</value>
+  </data>
+  <data name="ChartManage_Filter_StreamerSafe" xml:space="preserve">
+    <value>配信向け</value>
+  </data>
+  <data name="ChartManage_GetCharts_Description" xml:space="preserve">
+    <value>ウェブで譜面を閲覧 &amp; ダウンロード</value>
+  </data>
+  <data name="ChartManage_GetCharts_Title" xml:space="preserve">
+    <value>譜面を入手</value>
+  </data>
+  <data name="ChartManage_MigrateMdm" xml:space="preserve">
+    <value>MDM の譜面を移行</value>
+  </data>
+  <data name="ChartManage_Rating" xml:space="preserve">
+    <value>レベル</value>
+  </data>
+  <data name="ChartManage_Reset" xml:space="preserve">
+    <value>リセット</value>
+  </data>
+  <data name="ChartManage_SortBy" xml:space="preserve">
+    <value>並べ替え</value>
+  </data>
+  <data name="ChartManage_Tag_Video" xml:space="preserve">
+    <value>動画</value>
+  </data>
+  <data name="ChartManage_UpdateAll" xml:space="preserve">
+    <value>すべての譜面を更新</value>
+  </data>
+  <data name="ChartManage_UploadedBy" xml:space="preserve">
+    <value>投稿者：{0}</value>
+  </data>
+  <data name="ChartSortField_Author" xml:space="preserve">
+    <value>作者</value>
+  </data>
+  <data name="ChartSortField_Bpm" xml:space="preserve">
+    <value>BPM</value>
+  </data>
+  <data name="ChartSortField_DateAdded" xml:space="preserve">
+    <value>追加日</value>
+  </data>
+  <data name="ChartSortField_DateUpdated" xml:space="preserve">
+    <value>更新日</value>
+  </data>
+  <data name="ChartSortField_MapCount" xml:space="preserve">
+    <value>マップ数</value>
+  </data>
+  <data name="ChartSortField_Name" xml:space="preserve">
+    <value>名前</value>
+  </data>
+  <data name="ChartSortField_Rating" xml:space="preserve">
+    <value>レベル</value>
+  </data>
+  <data name="ChartSortField_Size" xml:space="preserve">
+    <value>ファイルサイズ</value>
+  </data>
+  <data name="ChartSource_Offline" xml:space="preserve">
+    <value>Offline</value>
+  </data>
+  <data name="ChartSource_Online" xml:space="preserve">
+    <value>Online</value>
+  </data>
   <data name="Contributor_Artist" xml:space="preserve">
     <value>アーティスト</value>
   </data>
@@ -489,71 +564,5 @@
   </data>
   <data name="Wizard_Title_Welcome" xml:space="preserve">
     <value>Euterpe へようこそ</value>
-  </data>
-  <data name="ChartManage_Bpm" xml:space="preserve">
-    <value>BPM</value>
-  </data>
-  <data name="ChartManage_Delete" xml:space="preserve">
-    <value>削除</value>
-  </data>
-  <data name="ChartManage_Descending" xml:space="preserve">
-    <value>降順</value>
-  </data>
-  <data name="ChartManage_Filter_Difficulty" xml:space="preserve">
-    <value>難易度</value>
-  </data>
-  <data name="ChartManage_Filter_HasVideo" xml:space="preserve">
-    <value>動画あり</value>
-  </data>
-  <data name="ChartManage_Filter_StreamerSafe" xml:space="preserve">
-    <value>配信向け</value>
-  </data>
-  <data name="ChartManage_GetCharts_Description" xml:space="preserve">
-    <value>ウェブで譜面を閲覧 &amp; ダウンロード</value>
-  </data>
-  <data name="ChartManage_GetCharts_Title" xml:space="preserve">
-    <value>譜面を入手</value>
-  </data>
-  <data name="ChartManage_Rating" xml:space="preserve">
-    <value>レベル</value>
-  </data>
-  <data name="ChartManage_Reset" xml:space="preserve">
-    <value>リセット</value>
-  </data>
-  <data name="ChartManage_Sort_DateAdded" xml:space="preserve">
-    <value>追加日</value>
-  </data>
-  <data name="ChartManage_Sort_DateUpdated" xml:space="preserve">
-    <value>更新日</value>
-  </data>
-  <data name="ChartManage_Sort_Maps" xml:space="preserve">
-    <value>マップ数</value>
-  </data>
-  <data name="ChartManage_Sort_Name" xml:space="preserve">
-    <value>名前</value>
-  </data>
-  <data name="ChartManage_SortBy" xml:space="preserve">
-    <value>並べ替え</value>
-  </data>
-  <data name="ChartManage_Tag_Video" xml:space="preserve">
-    <value>動画</value>
-  </data>
-  <data name="ChartManage_UploadedBy" xml:space="preserve">
-    <value>投稿者：{0}</value>
-  </data>
-  <data name="ChartSource_Offline" xml:space="preserve">
-    <value>Offline</value>
-  </data>
-  <data name="ChartSource_Online" xml:space="preserve">
-    <value>Online</value>
-  </data>
-  <data name="ChartManage_UpdateAll" xml:space="preserve">
-    <value>すべての譜面を更新</value>
-  </data>
-  <data name="ChartManage_MigrateMdm" xml:space="preserve">
-    <value>MDM の譜面を移行</value>
-  </data>
-  <data name="ChartManage_Sort_FileSize" xml:space="preserve">
-    <value>ファイルサイズ</value>
   </data>
 </root>

--- a/src/Euterpe.Localization/XAML/XAML.ko.resx
+++ b/src/Euterpe.Localization/XAML/XAML.ko.resx
@@ -73,6 +73,81 @@
   <data name="ChartDifficulty_Master" xml:space="preserve">
     <value>마스터</value>
   </data>
+  <data name="ChartManage_Bpm" xml:space="preserve">
+    <value>BPM</value>
+  </data>
+  <data name="ChartManage_Delete" xml:space="preserve">
+    <value>삭제</value>
+  </data>
+  <data name="ChartManage_Descending" xml:space="preserve">
+    <value>내림차순</value>
+  </data>
+  <data name="ChartManage_Filter_Difficulty" xml:space="preserve">
+    <value>난이도</value>
+  </data>
+  <data name="ChartManage_Filter_HasVideo" xml:space="preserve">
+    <value>영상 있음</value>
+  </data>
+  <data name="ChartManage_Filter_StreamerSafe" xml:space="preserve">
+    <value>방송 가능</value>
+  </data>
+  <data name="ChartManage_GetCharts_Description" xml:space="preserve">
+    <value>웹에서 채보 둘러보기 &amp; 다운로드</value>
+  </data>
+  <data name="ChartManage_GetCharts_Title" xml:space="preserve">
+    <value>채보 받기</value>
+  </data>
+  <data name="ChartManage_MigrateMdm" xml:space="preserve">
+    <value>MDM 채보 마이그레이션</value>
+  </data>
+  <data name="ChartManage_Rating" xml:space="preserve">
+    <value>레벨</value>
+  </data>
+  <data name="ChartManage_Reset" xml:space="preserve">
+    <value>초기화</value>
+  </data>
+  <data name="ChartManage_SortBy" xml:space="preserve">
+    <value>정렬 기준</value>
+  </data>
+  <data name="ChartManage_Tag_Video" xml:space="preserve">
+    <value>영상</value>
+  </data>
+  <data name="ChartManage_UpdateAll" xml:space="preserve">
+    <value>모든 채보 업데이트</value>
+  </data>
+  <data name="ChartManage_UploadedBy" xml:space="preserve">
+    <value>업로더: {0}</value>
+  </data>
+  <data name="ChartSortField_Author" xml:space="preserve">
+    <value>작성자</value>
+  </data>
+  <data name="ChartSortField_Bpm" xml:space="preserve">
+    <value>BPM</value>
+  </data>
+  <data name="ChartSortField_DateAdded" xml:space="preserve">
+    <value>추가한 날짜</value>
+  </data>
+  <data name="ChartSortField_DateUpdated" xml:space="preserve">
+    <value>업데이트한 날짜</value>
+  </data>
+  <data name="ChartSortField_MapCount" xml:space="preserve">
+    <value>맵 수</value>
+  </data>
+  <data name="ChartSortField_Name" xml:space="preserve">
+    <value>이름</value>
+  </data>
+  <data name="ChartSortField_Rating" xml:space="preserve">
+    <value>레벨</value>
+  </data>
+  <data name="ChartSortField_Size" xml:space="preserve">
+    <value>파일 크기</value>
+  </data>
+  <data name="ChartSource_Offline" xml:space="preserve">
+    <value>Offline</value>
+  </data>
+  <data name="ChartSource_Online" xml:space="preserve">
+    <value>Online</value>
+  </data>
   <data name="Contributor_Artist" xml:space="preserve">
     <value>아티스트</value>
   </data>
@@ -489,71 +564,5 @@
   </data>
   <data name="Wizard_Title_Welcome" xml:space="preserve">
     <value>Euterpe에 오신 것을 환영합니다</value>
-  </data>
-  <data name="ChartManage_Bpm" xml:space="preserve">
-    <value>BPM</value>
-  </data>
-  <data name="ChartManage_Delete" xml:space="preserve">
-    <value>삭제</value>
-  </data>
-  <data name="ChartManage_Descending" xml:space="preserve">
-    <value>내림차순</value>
-  </data>
-  <data name="ChartManage_Filter_Difficulty" xml:space="preserve">
-    <value>난이도</value>
-  </data>
-  <data name="ChartManage_Filter_HasVideo" xml:space="preserve">
-    <value>영상 있음</value>
-  </data>
-  <data name="ChartManage_Filter_StreamerSafe" xml:space="preserve">
-    <value>방송 가능</value>
-  </data>
-  <data name="ChartManage_GetCharts_Description" xml:space="preserve">
-    <value>웹에서 채보 둘러보기 &amp; 다운로드</value>
-  </data>
-  <data name="ChartManage_GetCharts_Title" xml:space="preserve">
-    <value>채보 받기</value>
-  </data>
-  <data name="ChartManage_Rating" xml:space="preserve">
-    <value>레벨</value>
-  </data>
-  <data name="ChartManage_Reset" xml:space="preserve">
-    <value>초기화</value>
-  </data>
-  <data name="ChartManage_Sort_DateAdded" xml:space="preserve">
-    <value>추가한 날짜</value>
-  </data>
-  <data name="ChartManage_Sort_DateUpdated" xml:space="preserve">
-    <value>업데이트한 날짜</value>
-  </data>
-  <data name="ChartManage_Sort_Maps" xml:space="preserve">
-    <value>맵 수</value>
-  </data>
-  <data name="ChartManage_Sort_Name" xml:space="preserve">
-    <value>이름</value>
-  </data>
-  <data name="ChartManage_SortBy" xml:space="preserve">
-    <value>정렬 기준</value>
-  </data>
-  <data name="ChartManage_Tag_Video" xml:space="preserve">
-    <value>영상</value>
-  </data>
-  <data name="ChartManage_UploadedBy" xml:space="preserve">
-    <value>업로더: {0}</value>
-  </data>
-  <data name="ChartSource_Offline" xml:space="preserve">
-    <value>Offline</value>
-  </data>
-  <data name="ChartSource_Online" xml:space="preserve">
-    <value>Online</value>
-  </data>
-  <data name="ChartManage_UpdateAll" xml:space="preserve">
-    <value>모든 채보 업데이트</value>
-  </data>
-  <data name="ChartManage_MigrateMdm" xml:space="preserve">
-    <value>MDM 채보 마이그레이션</value>
-  </data>
-  <data name="ChartManage_Sort_FileSize" xml:space="preserve">
-    <value>파일 크기</value>
   </data>
 </root>

--- a/src/Euterpe.Localization/XAML/XAML.nl.resx
+++ b/src/Euterpe.Localization/XAML/XAML.nl.resx
@@ -73,6 +73,81 @@
   <data name="ChartDifficulty_Master" xml:space="preserve">
     <value>Master</value>
   </data>
+  <data name="ChartManage_Bpm" xml:space="preserve">
+    <value>BPM</value>
+  </data>
+  <data name="ChartManage_Delete" xml:space="preserve">
+    <value>Verwijderen</value>
+  </data>
+  <data name="ChartManage_Descending" xml:space="preserve">
+    <value>Aflopend</value>
+  </data>
+  <data name="ChartManage_Filter_Difficulty" xml:space="preserve">
+    <value>Moeilijkheid</value>
+  </data>
+  <data name="ChartManage_Filter_HasVideo" xml:space="preserve">
+    <value>Met video</value>
+  </data>
+  <data name="ChartManage_Filter_StreamerSafe" xml:space="preserve">
+    <value>Streamveilig</value>
+  </data>
+  <data name="ChartManage_GetCharts_Description" xml:space="preserve">
+    <value>Charts zoeken &amp; downloaden op het web</value>
+  </data>
+  <data name="ChartManage_GetCharts_Title" xml:space="preserve">
+    <value>Charts ophalen</value>
+  </data>
+  <data name="ChartManage_MigrateMdm" xml:space="preserve">
+    <value>MDM-charts migreren</value>
+  </data>
+  <data name="ChartManage_Rating" xml:space="preserve">
+    <value>Niveau</value>
+  </data>
+  <data name="ChartManage_Reset" xml:space="preserve">
+    <value>Herstellen</value>
+  </data>
+  <data name="ChartManage_SortBy" xml:space="preserve">
+    <value>Sorteren op</value>
+  </data>
+  <data name="ChartManage_Tag_Video" xml:space="preserve">
+    <value>Video</value>
+  </data>
+  <data name="ChartManage_UpdateAll" xml:space="preserve">
+    <value>Alle charts bijwerken</value>
+  </data>
+  <data name="ChartManage_UploadedBy" xml:space="preserve">
+    <value>door {0}</value>
+  </data>
+  <data name="ChartSortField_Author" xml:space="preserve">
+    <value>Auteur</value>
+  </data>
+  <data name="ChartSortField_Bpm" xml:space="preserve">
+    <value>BPM</value>
+  </data>
+  <data name="ChartSortField_DateAdded" xml:space="preserve">
+    <value>Toegevoegd op</value>
+  </data>
+  <data name="ChartSortField_DateUpdated" xml:space="preserve">
+    <value>Bijgewerkt op</value>
+  </data>
+  <data name="ChartSortField_MapCount" xml:space="preserve">
+    <value>Maps</value>
+  </data>
+  <data name="ChartSortField_Name" xml:space="preserve">
+    <value>Naam</value>
+  </data>
+  <data name="ChartSortField_Rating" xml:space="preserve">
+    <value>Niveau</value>
+  </data>
+  <data name="ChartSortField_Size" xml:space="preserve">
+    <value>Bestandsgrootte</value>
+  </data>
+  <data name="ChartSource_Offline" xml:space="preserve">
+    <value>Offline</value>
+  </data>
+  <data name="ChartSource_Online" xml:space="preserve">
+    <value>Online</value>
+  </data>
   <data name="Contributor_Artist" xml:space="preserve">
     <value>Artiest</value>
   </data>
@@ -489,71 +564,5 @@
   </data>
   <data name="Wizard_Title_Welcome" xml:space="preserve">
     <value>Welkom bij Euterpe</value>
-  </data>
-  <data name="ChartManage_Bpm" xml:space="preserve">
-    <value>BPM</value>
-  </data>
-  <data name="ChartManage_Delete" xml:space="preserve">
-    <value>Verwijderen</value>
-  </data>
-  <data name="ChartManage_Descending" xml:space="preserve">
-    <value>Aflopend</value>
-  </data>
-  <data name="ChartManage_Filter_Difficulty" xml:space="preserve">
-    <value>Moeilijkheid</value>
-  </data>
-  <data name="ChartManage_Filter_HasVideo" xml:space="preserve">
-    <value>Met video</value>
-  </data>
-  <data name="ChartManage_Filter_StreamerSafe" xml:space="preserve">
-    <value>Streamveilig</value>
-  </data>
-  <data name="ChartManage_GetCharts_Description" xml:space="preserve">
-    <value>Charts zoeken &amp; downloaden op het web</value>
-  </data>
-  <data name="ChartManage_GetCharts_Title" xml:space="preserve">
-    <value>Charts ophalen</value>
-  </data>
-  <data name="ChartManage_Rating" xml:space="preserve">
-    <value>Niveau</value>
-  </data>
-  <data name="ChartManage_Reset" xml:space="preserve">
-    <value>Herstellen</value>
-  </data>
-  <data name="ChartManage_Sort_DateAdded" xml:space="preserve">
-    <value>Toegevoegd op</value>
-  </data>
-  <data name="ChartManage_Sort_DateUpdated" xml:space="preserve">
-    <value>Bijgewerkt op</value>
-  </data>
-  <data name="ChartManage_Sort_Maps" xml:space="preserve">
-    <value>Maps</value>
-  </data>
-  <data name="ChartManage_Sort_Name" xml:space="preserve">
-    <value>Naam</value>
-  </data>
-  <data name="ChartManage_SortBy" xml:space="preserve">
-    <value>Sorteren op</value>
-  </data>
-  <data name="ChartManage_Tag_Video" xml:space="preserve">
-    <value>Video</value>
-  </data>
-  <data name="ChartManage_UploadedBy" xml:space="preserve">
-    <value>door {0}</value>
-  </data>
-  <data name="ChartSource_Offline" xml:space="preserve">
-    <value>Offline</value>
-  </data>
-  <data name="ChartSource_Online" xml:space="preserve">
-    <value>Online</value>
-  </data>
-  <data name="ChartManage_UpdateAll" xml:space="preserve">
-    <value>Alle charts bijwerken</value>
-  </data>
-  <data name="ChartManage_MigrateMdm" xml:space="preserve">
-    <value>MDM-charts migreren</value>
-  </data>
-  <data name="ChartManage_Sort_FileSize" xml:space="preserve">
-    <value>Bestandsgrootte</value>
   </data>
 </root>

--- a/src/Euterpe.Localization/XAML/XAML.pt.resx
+++ b/src/Euterpe.Localization/XAML/XAML.pt.resx
@@ -73,6 +73,81 @@
   <data name="ChartDifficulty_Master" xml:space="preserve">
     <value>Master</value>
   </data>
+  <data name="ChartManage_Bpm" xml:space="preserve">
+    <value>BPM</value>
+  </data>
+  <data name="ChartManage_Delete" xml:space="preserve">
+    <value>Excluir</value>
+  </data>
+  <data name="ChartManage_Descending" xml:space="preserve">
+    <value>Decrescente</value>
+  </data>
+  <data name="ChartManage_Filter_Difficulty" xml:space="preserve">
+    <value>Dificuldade</value>
+  </data>
+  <data name="ChartManage_Filter_HasVideo" xml:space="preserve">
+    <value>Com vídeo</value>
+  </data>
+  <data name="ChartManage_Filter_StreamerSafe" xml:space="preserve">
+    <value>Seguro para transmissão</value>
+  </data>
+  <data name="ChartManage_GetCharts_Description" xml:space="preserve">
+    <value>Explore &amp; baixe charts na web</value>
+  </data>
+  <data name="ChartManage_GetCharts_Title" xml:space="preserve">
+    <value>Obter charts</value>
+  </data>
+  <data name="ChartManage_MigrateMdm" xml:space="preserve">
+    <value>Migrar charts do MDM</value>
+  </data>
+  <data name="ChartManage_Rating" xml:space="preserve">
+    <value>Nível</value>
+  </data>
+  <data name="ChartManage_Reset" xml:space="preserve">
+    <value>Redefinir</value>
+  </data>
+  <data name="ChartManage_SortBy" xml:space="preserve">
+    <value>Ordenar por</value>
+  </data>
+  <data name="ChartManage_Tag_Video" xml:space="preserve">
+    <value>Vídeo</value>
+  </data>
+  <data name="ChartManage_UpdateAll" xml:space="preserve">
+    <value>Atualizar todos os charts</value>
+  </data>
+  <data name="ChartManage_UploadedBy" xml:space="preserve">
+    <value>por {0}</value>
+  </data>
+  <data name="ChartSortField_Author" xml:space="preserve">
+    <value>Autor</value>
+  </data>
+  <data name="ChartSortField_Bpm" xml:space="preserve">
+    <value>BPM</value>
+  </data>
+  <data name="ChartSortField_DateAdded" xml:space="preserve">
+    <value>Data de adição</value>
+  </data>
+  <data name="ChartSortField_DateUpdated" xml:space="preserve">
+    <value>Data de atualização</value>
+  </data>
+  <data name="ChartSortField_MapCount" xml:space="preserve">
+    <value>Mapas</value>
+  </data>
+  <data name="ChartSortField_Name" xml:space="preserve">
+    <value>Nome</value>
+  </data>
+  <data name="ChartSortField_Rating" xml:space="preserve">
+    <value>Nível</value>
+  </data>
+  <data name="ChartSortField_Size" xml:space="preserve">
+    <value>Tamanho do arquivo</value>
+  </data>
+  <data name="ChartSource_Offline" xml:space="preserve">
+    <value>Offline</value>
+  </data>
+  <data name="ChartSource_Online" xml:space="preserve">
+    <value>Online</value>
+  </data>
   <data name="Contributor_Artist" xml:space="preserve">
     <value>Artista</value>
   </data>
@@ -489,71 +564,5 @@
   </data>
   <data name="Wizard_Title_Welcome" xml:space="preserve">
     <value>Bem-vindo ao Euterpe</value>
-  </data>
-  <data name="ChartManage_Bpm" xml:space="preserve">
-    <value>BPM</value>
-  </data>
-  <data name="ChartManage_Delete" xml:space="preserve">
-    <value>Excluir</value>
-  </data>
-  <data name="ChartManage_Descending" xml:space="preserve">
-    <value>Decrescente</value>
-  </data>
-  <data name="ChartManage_Filter_Difficulty" xml:space="preserve">
-    <value>Dificuldade</value>
-  </data>
-  <data name="ChartManage_Filter_HasVideo" xml:space="preserve">
-    <value>Com vídeo</value>
-  </data>
-  <data name="ChartManage_Filter_StreamerSafe" xml:space="preserve">
-    <value>Seguro para transmissão</value>
-  </data>
-  <data name="ChartManage_GetCharts_Description" xml:space="preserve">
-    <value>Explore &amp; baixe charts na web</value>
-  </data>
-  <data name="ChartManage_GetCharts_Title" xml:space="preserve">
-    <value>Obter charts</value>
-  </data>
-  <data name="ChartManage_Rating" xml:space="preserve">
-    <value>Nível</value>
-  </data>
-  <data name="ChartManage_Reset" xml:space="preserve">
-    <value>Redefinir</value>
-  </data>
-  <data name="ChartManage_Sort_DateAdded" xml:space="preserve">
-    <value>Data de adição</value>
-  </data>
-  <data name="ChartManage_Sort_DateUpdated" xml:space="preserve">
-    <value>Data de atualização</value>
-  </data>
-  <data name="ChartManage_Sort_Maps" xml:space="preserve">
-    <value>Mapas</value>
-  </data>
-  <data name="ChartManage_Sort_Name" xml:space="preserve">
-    <value>Nome</value>
-  </data>
-  <data name="ChartManage_SortBy" xml:space="preserve">
-    <value>Ordenar por</value>
-  </data>
-  <data name="ChartManage_Tag_Video" xml:space="preserve">
-    <value>Vídeo</value>
-  </data>
-  <data name="ChartManage_UploadedBy" xml:space="preserve">
-    <value>por {0}</value>
-  </data>
-  <data name="ChartSource_Offline" xml:space="preserve">
-    <value>Offline</value>
-  </data>
-  <data name="ChartSource_Online" xml:space="preserve">
-    <value>Online</value>
-  </data>
-  <data name="ChartManage_UpdateAll" xml:space="preserve">
-    <value>Atualizar todos os charts</value>
-  </data>
-  <data name="ChartManage_MigrateMdm" xml:space="preserve">
-    <value>Migrar charts do MDM</value>
-  </data>
-  <data name="ChartManage_Sort_FileSize" xml:space="preserve">
-    <value>Tamanho do arquivo</value>
   </data>
 </root>

--- a/src/Euterpe.Localization/XAML/XAML.resx
+++ b/src/Euterpe.Localization/XAML/XAML.resx
@@ -73,6 +73,81 @@
   <data name="ChartDifficulty_Master" xml:space="preserve">
     <value>Master</value>
   </data>
+  <data name="ChartManage_Bpm" xml:space="preserve">
+    <value>BPM</value>
+  </data>
+  <data name="ChartManage_Delete" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="ChartManage_Descending" xml:space="preserve">
+    <value>Descending</value>
+  </data>
+  <data name="ChartManage_Filter_Difficulty" xml:space="preserve">
+    <value>Difficulty</value>
+  </data>
+  <data name="ChartManage_Filter_HasVideo" xml:space="preserve">
+    <value>Has video</value>
+  </data>
+  <data name="ChartManage_Filter_StreamerSafe" xml:space="preserve">
+    <value>Streamer safe</value>
+  </data>
+  <data name="ChartManage_GetCharts_Description" xml:space="preserve">
+    <value>Browse &amp; download charts on the web</value>
+  </data>
+  <data name="ChartManage_GetCharts_Title" xml:space="preserve">
+    <value>Get Charts</value>
+  </data>
+  <data name="ChartManage_MigrateMdm" xml:space="preserve">
+    <value>Migrate MDM Charts</value>
+  </data>
+  <data name="ChartManage_Rating" xml:space="preserve">
+    <value>Rating</value>
+  </data>
+  <data name="ChartManage_Reset" xml:space="preserve">
+    <value>Reset</value>
+  </data>
+  <data name="ChartManage_SortBy" xml:space="preserve">
+    <value>Sort by</value>
+  </data>
+  <data name="ChartManage_Tag_Video" xml:space="preserve">
+    <value>Video</value>
+  </data>
+  <data name="ChartManage_UpdateAll" xml:space="preserve">
+    <value>Update All Charts</value>
+  </data>
+  <data name="ChartManage_UploadedBy" xml:space="preserve">
+    <value>by {0}</value>
+  </data>
+  <data name="ChartSortField_Author" xml:space="preserve">
+    <value>Author</value>
+  </data>
+  <data name="ChartSortField_Bpm" xml:space="preserve">
+    <value>BPM</value>
+  </data>
+  <data name="ChartSortField_DateAdded" xml:space="preserve">
+    <value>Date added</value>
+  </data>
+  <data name="ChartSortField_DateUpdated" xml:space="preserve">
+    <value>Date updated</value>
+  </data>
+  <data name="ChartSortField_MapCount" xml:space="preserve">
+    <value>Maps</value>
+  </data>
+  <data name="ChartSortField_Name" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="ChartSortField_Rating" xml:space="preserve">
+    <value>Rating</value>
+  </data>
+  <data name="ChartSortField_Size" xml:space="preserve">
+    <value>File size</value>
+  </data>
+  <data name="ChartSource_Offline" xml:space="preserve">
+    <value>Offline</value>
+  </data>
+  <data name="ChartSource_Online" xml:space="preserve">
+    <value>Online</value>
+  </data>
   <data name="Contributor_Artist" xml:space="preserve">
     <value>Artist</value>
   </data>
@@ -516,71 +591,5 @@
   </data>
   <data name="Wizard_Title_Welcome" xml:space="preserve">
     <value>Welcome to Euterpe</value>
-  </data>
-  <data name="ChartManage_Bpm" xml:space="preserve">
-    <value>BPM</value>
-  </data>
-  <data name="ChartManage_Delete" xml:space="preserve">
-    <value>Delete</value>
-  </data>
-  <data name="ChartManage_Descending" xml:space="preserve">
-    <value>Descending</value>
-  </data>
-  <data name="ChartManage_Filter_Difficulty" xml:space="preserve">
-    <value>Difficulty</value>
-  </data>
-  <data name="ChartManage_Filter_HasVideo" xml:space="preserve">
-    <value>Has video</value>
-  </data>
-  <data name="ChartManage_Filter_StreamerSafe" xml:space="preserve">
-    <value>Streamer safe</value>
-  </data>
-  <data name="ChartManage_GetCharts_Description" xml:space="preserve">
-    <value>Browse &amp; download charts on the web</value>
-  </data>
-  <data name="ChartManage_GetCharts_Title" xml:space="preserve">
-    <value>Get Charts</value>
-  </data>
-  <data name="ChartManage_Rating" xml:space="preserve">
-    <value>Rating</value>
-  </data>
-  <data name="ChartManage_Reset" xml:space="preserve">
-    <value>Reset</value>
-  </data>
-  <data name="ChartManage_Sort_DateAdded" xml:space="preserve">
-    <value>Date added</value>
-  </data>
-  <data name="ChartManage_Sort_DateUpdated" xml:space="preserve">
-    <value>Date updated</value>
-  </data>
-  <data name="ChartManage_Sort_Maps" xml:space="preserve">
-    <value>Maps</value>
-  </data>
-  <data name="ChartManage_Sort_Name" xml:space="preserve">
-    <value>Name</value>
-  </data>
-  <data name="ChartManage_SortBy" xml:space="preserve">
-    <value>Sort by</value>
-  </data>
-  <data name="ChartManage_Tag_Video" xml:space="preserve">
-    <value>Video</value>
-  </data>
-  <data name="ChartManage_UploadedBy" xml:space="preserve">
-    <value>by {0}</value>
-  </data>
-  <data name="ChartSource_Offline" xml:space="preserve">
-    <value>Offline</value>
-  </data>
-  <data name="ChartSource_Online" xml:space="preserve">
-    <value>Online</value>
-  </data>
-  <data name="ChartManage_UpdateAll" xml:space="preserve">
-    <value>Update All Charts</value>
-  </data>
-  <data name="ChartManage_MigrateMdm" xml:space="preserve">
-    <value>Migrate MDM Charts</value>
-  </data>
-  <data name="ChartManage_Sort_FileSize" xml:space="preserve">
-    <value>File Size</value>
   </data>
 </root>

--- a/src/Euterpe.Localization/XAML/XAML.ru.resx
+++ b/src/Euterpe.Localization/XAML/XAML.ru.resx
@@ -73,6 +73,81 @@
   <data name="ChartDifficulty_Master" xml:space="preserve">
     <value>Мастер</value>
   </data>
+  <data name="ChartManage_Bpm" xml:space="preserve">
+    <value>BPM</value>
+  </data>
+  <data name="ChartManage_Delete" xml:space="preserve">
+    <value>Удалить</value>
+  </data>
+  <data name="ChartManage_Descending" xml:space="preserve">
+    <value>По убыванию</value>
+  </data>
+  <data name="ChartManage_Filter_Difficulty" xml:space="preserve">
+    <value>Сложность</value>
+  </data>
+  <data name="ChartManage_Filter_HasVideo" xml:space="preserve">
+    <value>С видео</value>
+  </data>
+  <data name="ChartManage_Filter_StreamerSafe" xml:space="preserve">
+    <value>Безопасно для стрима</value>
+  </data>
+  <data name="ChartManage_GetCharts_Description" xml:space="preserve">
+    <value>Просмотр и загрузка чартов в сети</value>
+  </data>
+  <data name="ChartManage_GetCharts_Title" xml:space="preserve">
+    <value>Получить чарты</value>
+  </data>
+  <data name="ChartManage_MigrateMdm" xml:space="preserve">
+    <value>Перенести чарты MDM</value>
+  </data>
+  <data name="ChartManage_Rating" xml:space="preserve">
+    <value>Уровень</value>
+  </data>
+  <data name="ChartManage_Reset" xml:space="preserve">
+    <value>Сбросить</value>
+  </data>
+  <data name="ChartManage_SortBy" xml:space="preserve">
+    <value>Сортировать по</value>
+  </data>
+  <data name="ChartManage_Tag_Video" xml:space="preserve">
+    <value>Видео</value>
+  </data>
+  <data name="ChartManage_UpdateAll" xml:space="preserve">
+    <value>Обновить все чарты</value>
+  </data>
+  <data name="ChartManage_UploadedBy" xml:space="preserve">
+    <value>от {0}</value>
+  </data>
+  <data name="ChartSortField_Author" xml:space="preserve">
+    <value>Автор</value>
+  </data>
+  <data name="ChartSortField_Bpm" xml:space="preserve">
+    <value>BPM</value>
+  </data>
+  <data name="ChartSortField_DateAdded" xml:space="preserve">
+    <value>Дата добавления</value>
+  </data>
+  <data name="ChartSortField_DateUpdated" xml:space="preserve">
+    <value>Дата обновления</value>
+  </data>
+  <data name="ChartSortField_MapCount" xml:space="preserve">
+    <value>Карты</value>
+  </data>
+  <data name="ChartSortField_Name" xml:space="preserve">
+    <value>Название</value>
+  </data>
+  <data name="ChartSortField_Rating" xml:space="preserve">
+    <value>Уровень</value>
+  </data>
+  <data name="ChartSortField_Size" xml:space="preserve">
+    <value>Размер файла</value>
+  </data>
+  <data name="ChartSource_Offline" xml:space="preserve">
+    <value>Offline</value>
+  </data>
+  <data name="ChartSource_Online" xml:space="preserve">
+    <value>Online</value>
+  </data>
   <data name="Contributor_Artist" xml:space="preserve">
     <value>Художник</value>
   </data>
@@ -489,71 +564,5 @@
   </data>
   <data name="Wizard_Title_Welcome" xml:space="preserve">
     <value>Добро пожаловать в Euterpe</value>
-  </data>
-  <data name="ChartManage_Bpm" xml:space="preserve">
-    <value>BPM</value>
-  </data>
-  <data name="ChartManage_Delete" xml:space="preserve">
-    <value>Удалить</value>
-  </data>
-  <data name="ChartManage_Descending" xml:space="preserve">
-    <value>По убыванию</value>
-  </data>
-  <data name="ChartManage_Filter_Difficulty" xml:space="preserve">
-    <value>Сложность</value>
-  </data>
-  <data name="ChartManage_Filter_HasVideo" xml:space="preserve">
-    <value>С видео</value>
-  </data>
-  <data name="ChartManage_Filter_StreamerSafe" xml:space="preserve">
-    <value>Безопасно для стрима</value>
-  </data>
-  <data name="ChartManage_GetCharts_Description" xml:space="preserve">
-    <value>Просмотр и загрузка чартов в сети</value>
-  </data>
-  <data name="ChartManage_GetCharts_Title" xml:space="preserve">
-    <value>Получить чарты</value>
-  </data>
-  <data name="ChartManage_Rating" xml:space="preserve">
-    <value>Уровень</value>
-  </data>
-  <data name="ChartManage_Reset" xml:space="preserve">
-    <value>Сбросить</value>
-  </data>
-  <data name="ChartManage_Sort_DateAdded" xml:space="preserve">
-    <value>Дата добавления</value>
-  </data>
-  <data name="ChartManage_Sort_DateUpdated" xml:space="preserve">
-    <value>Дата обновления</value>
-  </data>
-  <data name="ChartManage_Sort_Maps" xml:space="preserve">
-    <value>Карты</value>
-  </data>
-  <data name="ChartManage_Sort_Name" xml:space="preserve">
-    <value>Название</value>
-  </data>
-  <data name="ChartManage_SortBy" xml:space="preserve">
-    <value>Сортировать по</value>
-  </data>
-  <data name="ChartManage_Tag_Video" xml:space="preserve">
-    <value>Видео</value>
-  </data>
-  <data name="ChartManage_UploadedBy" xml:space="preserve">
-    <value>от {0}</value>
-  </data>
-  <data name="ChartSource_Offline" xml:space="preserve">
-    <value>Offline</value>
-  </data>
-  <data name="ChartSource_Online" xml:space="preserve">
-    <value>Online</value>
-  </data>
-  <data name="ChartManage_UpdateAll" xml:space="preserve">
-    <value>Обновить все чарты</value>
-  </data>
-  <data name="ChartManage_MigrateMdm" xml:space="preserve">
-    <value>Перенести чарты MDM</value>
-  </data>
-  <data name="ChartManage_Sort_FileSize" xml:space="preserve">
-    <value>Размер файла</value>
   </data>
 </root>

--- a/src/Euterpe.Localization/XAML/XAML.zh-Hans.resx
+++ b/src/Euterpe.Localization/XAML/XAML.zh-Hans.resx
@@ -73,6 +73,81 @@
   <data name="ChartDifficulty_Master" xml:space="preserve">
     <value>大触</value>
   </data>
+  <data name="ChartManage_Bpm" xml:space="preserve">
+    <value>BPM</value>
+  </data>
+  <data name="ChartManage_Delete" xml:space="preserve">
+    <value>删除</value>
+  </data>
+  <data name="ChartManage_Descending" xml:space="preserve">
+    <value>降序</value>
+  </data>
+  <data name="ChartManage_Filter_Difficulty" xml:space="preserve">
+    <value>难度</value>
+  </data>
+  <data name="ChartManage_Filter_HasVideo" xml:space="preserve">
+    <value>含视频</value>
+  </data>
+  <data name="ChartManage_Filter_StreamerSafe" xml:space="preserve">
+    <value>可直播</value>
+  </data>
+  <data name="ChartManage_GetCharts_Description" xml:space="preserve">
+    <value>浏览并下载谱面</value>
+  </data>
+  <data name="ChartManage_GetCharts_Title" xml:space="preserve">
+    <value>获取谱面</value>
+  </data>
+  <data name="ChartManage_MigrateMdm" xml:space="preserve">
+    <value>迁移 MDM 谱面</value>
+  </data>
+  <data name="ChartManage_Rating" xml:space="preserve">
+    <value>定数</value>
+  </data>
+  <data name="ChartManage_Reset" xml:space="preserve">
+    <value>重置</value>
+  </data>
+  <data name="ChartManage_SortBy" xml:space="preserve">
+    <value>排序方式</value>
+  </data>
+  <data name="ChartManage_Tag_Video" xml:space="preserve">
+    <value>视频</value>
+  </data>
+  <data name="ChartManage_UpdateAll" xml:space="preserve">
+    <value>更新全部谱面</value>
+  </data>
+  <data name="ChartManage_UploadedBy" xml:space="preserve">
+    <value>由 {0} 上传</value>
+  </data>
+  <data name="ChartSortField_Author" xml:space="preserve">
+    <value>作者</value>
+  </data>
+  <data name="ChartSortField_Bpm" xml:space="preserve">
+    <value>BPM</value>
+  </data>
+  <data name="ChartSortField_DateAdded" xml:space="preserve">
+    <value>添加日期</value>
+  </data>
+  <data name="ChartSortField_DateUpdated" xml:space="preserve">
+    <value>更新日期</value>
+  </data>
+  <data name="ChartSortField_MapCount" xml:space="preserve">
+    <value>地图数量</value>
+  </data>
+  <data name="ChartSortField_Name" xml:space="preserve">
+    <value>名称</value>
+  </data>
+  <data name="ChartSortField_Rating" xml:space="preserve">
+    <value>定数</value>
+  </data>
+  <data name="ChartSortField_Size" xml:space="preserve">
+    <value>文件大小</value>
+  </data>
+  <data name="ChartSource_Offline" xml:space="preserve">
+    <value>本地</value>
+  </data>
+  <data name="ChartSource_Online" xml:space="preserve">
+    <value>线上</value>
+  </data>
   <data name="Contributor_Artist" xml:space="preserve">
     <value>艺术家</value>
   </data>
@@ -510,71 +585,5 @@
   </data>
   <data name="Wizard_Title_Welcome" xml:space="preserve">
     <value>欢迎使用 Euterpe</value>
-  </data>
-  <data name="ChartManage_Bpm" xml:space="preserve">
-    <value>BPM</value>
-  </data>
-  <data name="ChartManage_Delete" xml:space="preserve">
-    <value>删除</value>
-  </data>
-  <data name="ChartManage_Descending" xml:space="preserve">
-    <value>降序</value>
-  </data>
-  <data name="ChartManage_Filter_Difficulty" xml:space="preserve">
-    <value>难度</value>
-  </data>
-  <data name="ChartManage_Filter_HasVideo" xml:space="preserve">
-    <value>含视频</value>
-  </data>
-  <data name="ChartManage_Filter_StreamerSafe" xml:space="preserve">
-    <value>可直播</value>
-  </data>
-  <data name="ChartManage_GetCharts_Description" xml:space="preserve">
-    <value>浏览并下载谱面</value>
-  </data>
-  <data name="ChartManage_GetCharts_Title" xml:space="preserve">
-    <value>获取谱面</value>
-  </data>
-  <data name="ChartManage_Rating" xml:space="preserve">
-    <value>定数</value>
-  </data>
-  <data name="ChartManage_Reset" xml:space="preserve">
-    <value>重置</value>
-  </data>
-  <data name="ChartManage_Sort_DateAdded" xml:space="preserve">
-    <value>添加日期</value>
-  </data>
-  <data name="ChartManage_Sort_DateUpdated" xml:space="preserve">
-    <value>更新日期</value>
-  </data>
-  <data name="ChartManage_Sort_Maps" xml:space="preserve">
-    <value>地图数量</value>
-  </data>
-  <data name="ChartManage_Sort_Name" xml:space="preserve">
-    <value>名称</value>
-  </data>
-  <data name="ChartManage_SortBy" xml:space="preserve">
-    <value>排序方式</value>
-  </data>
-  <data name="ChartManage_Tag_Video" xml:space="preserve">
-    <value>视频</value>
-  </data>
-  <data name="ChartManage_UploadedBy" xml:space="preserve">
-    <value>由 {0} 上传</value>
-  </data>
-  <data name="ChartSource_Offline" xml:space="preserve">
-    <value>本地</value>
-  </data>
-  <data name="ChartSource_Online" xml:space="preserve">
-    <value>线上</value>
-  </data>
-  <data name="ChartManage_UpdateAll" xml:space="preserve">
-    <value>更新全部谱面</value>
-  </data>
-  <data name="ChartManage_MigrateMdm" xml:space="preserve">
-    <value>迁移 MDM 谱面</value>
-  </data>
-  <data name="ChartManage_Sort_FileSize" xml:space="preserve">
-    <value>文件大小</value>
   </data>
 </root>

--- a/src/Euterpe.Localization/XAML/XAML.zh-Hant.resx
+++ b/src/Euterpe.Localization/XAML/XAML.zh-Hant.resx
@@ -73,6 +73,81 @@
   <data name="ChartDifficulty_Master" xml:space="preserve">
     <value>大觸</value>
   </data>
+  <data name="ChartManage_Bpm" xml:space="preserve">
+    <value>BPM</value>
+  </data>
+  <data name="ChartManage_Delete" xml:space="preserve">
+    <value>刪除</value>
+  </data>
+  <data name="ChartManage_Descending" xml:space="preserve">
+    <value>降序</value>
+  </data>
+  <data name="ChartManage_Filter_Difficulty" xml:space="preserve">
+    <value>難度</value>
+  </data>
+  <data name="ChartManage_Filter_HasVideo" xml:space="preserve">
+    <value>含影片</value>
+  </data>
+  <data name="ChartManage_Filter_StreamerSafe" xml:space="preserve">
+    <value>直播安全</value>
+  </data>
+  <data name="ChartManage_GetCharts_Description" xml:space="preserve">
+    <value>在網路上瀏覽並下載譜面</value>
+  </data>
+  <data name="ChartManage_GetCharts_Title" xml:space="preserve">
+    <value>取得譜面</value>
+  </data>
+  <data name="ChartManage_MigrateMdm" xml:space="preserve">
+    <value>遷移 MDM 譜面</value>
+  </data>
+  <data name="ChartManage_Rating" xml:space="preserve">
+    <value>定數</value>
+  </data>
+  <data name="ChartManage_Reset" xml:space="preserve">
+    <value>重設</value>
+  </data>
+  <data name="ChartManage_SortBy" xml:space="preserve">
+    <value>排序方式</value>
+  </data>
+  <data name="ChartManage_Tag_Video" xml:space="preserve">
+    <value>影片</value>
+  </data>
+  <data name="ChartManage_UpdateAll" xml:space="preserve">
+    <value>更新全部譜面</value>
+  </data>
+  <data name="ChartManage_UploadedBy" xml:space="preserve">
+    <value>由 {0} 上傳</value>
+  </data>
+  <data name="ChartSortField_Author" xml:space="preserve">
+    <value>作者</value>
+  </data>
+  <data name="ChartSortField_Bpm" xml:space="preserve">
+    <value>BPM</value>
+  </data>
+  <data name="ChartSortField_DateAdded" xml:space="preserve">
+    <value>新增日期</value>
+  </data>
+  <data name="ChartSortField_DateUpdated" xml:space="preserve">
+    <value>更新日期</value>
+  </data>
+  <data name="ChartSortField_MapCount" xml:space="preserve">
+    <value>地圖數量</value>
+  </data>
+  <data name="ChartSortField_Name" xml:space="preserve">
+    <value>名稱</value>
+  </data>
+  <data name="ChartSortField_Rating" xml:space="preserve">
+    <value>定數</value>
+  </data>
+  <data name="ChartSortField_Size" xml:space="preserve">
+    <value>檔案大小</value>
+  </data>
+  <data name="ChartSource_Offline" xml:space="preserve">
+    <value>本地</value>
+  </data>
+  <data name="ChartSource_Online" xml:space="preserve">
+    <value>線上</value>
+  </data>
   <data name="Contributor_Artist" xml:space="preserve">
     <value>美術設計</value>
   </data>
@@ -489,71 +564,5 @@
   </data>
   <data name="Wizard_Title_Welcome" xml:space="preserve">
     <value>歡迎使用 Euterpe</value>
-  </data>
-  <data name="ChartManage_Bpm" xml:space="preserve">
-    <value>BPM</value>
-  </data>
-  <data name="ChartManage_Delete" xml:space="preserve">
-    <value>刪除</value>
-  </data>
-  <data name="ChartManage_Descending" xml:space="preserve">
-    <value>降序</value>
-  </data>
-  <data name="ChartManage_Filter_Difficulty" xml:space="preserve">
-    <value>難度</value>
-  </data>
-  <data name="ChartManage_Filter_HasVideo" xml:space="preserve">
-    <value>含影片</value>
-  </data>
-  <data name="ChartManage_Filter_StreamerSafe" xml:space="preserve">
-    <value>直播安全</value>
-  </data>
-  <data name="ChartManage_GetCharts_Description" xml:space="preserve">
-    <value>在網路上瀏覽並下載譜面</value>
-  </data>
-  <data name="ChartManage_GetCharts_Title" xml:space="preserve">
-    <value>取得譜面</value>
-  </data>
-  <data name="ChartManage_Rating" xml:space="preserve">
-    <value>定數</value>
-  </data>
-  <data name="ChartManage_Reset" xml:space="preserve">
-    <value>重設</value>
-  </data>
-  <data name="ChartManage_Sort_DateAdded" xml:space="preserve">
-    <value>新增日期</value>
-  </data>
-  <data name="ChartManage_Sort_DateUpdated" xml:space="preserve">
-    <value>更新日期</value>
-  </data>
-  <data name="ChartManage_Sort_Maps" xml:space="preserve">
-    <value>地圖數量</value>
-  </data>
-  <data name="ChartManage_Sort_Name" xml:space="preserve">
-    <value>名稱</value>
-  </data>
-  <data name="ChartManage_SortBy" xml:space="preserve">
-    <value>排序方式</value>
-  </data>
-  <data name="ChartManage_Tag_Video" xml:space="preserve">
-    <value>影片</value>
-  </data>
-  <data name="ChartManage_UploadedBy" xml:space="preserve">
-    <value>由 {0} 上傳</value>
-  </data>
-  <data name="ChartSource_Offline" xml:space="preserve">
-    <value>本地</value>
-  </data>
-  <data name="ChartSource_Online" xml:space="preserve">
-    <value>線上</value>
-  </data>
-  <data name="ChartManage_UpdateAll" xml:space="preserve">
-    <value>更新全部譜面</value>
-  </data>
-  <data name="ChartManage_MigrateMdm" xml:space="preserve">
-    <value>遷移 MDM 譜面</value>
-  </data>
-  <data name="ChartManage_Sort_FileSize" xml:space="preserve">
-    <value>檔案大小</value>
   </data>
 </root>

--- a/src/Euterpe.Models/Charts/ChartFiles.cs
+++ b/src/Euterpe.Models/Charts/ChartFiles.cs
@@ -26,7 +26,7 @@ public static class ChartFiles
 
     public static string MapName(ChartDifficulty difficulty) => $"map{(int)difficulty}";
 
-    public static string MapFileName(ChartDifficulty difficulty) => $"{MapName(difficulty)}.bms";
+    public static string MapFileName(ChartDifficulty difficulty) => $"map{(int)difficulty}.bms";
 
     public static IReadOnlyList<ChartDifficulty> ExistingDifficulties(this IReadOnlyDictionary<string, ManifestFileEntry> files) =>
         [.. AllDifficulties.Where(difficulty => files.ContainsKey(MapFileName(difficulty)))];

--- a/src/Euterpe.Models/Charts/ChartSortField.cs
+++ b/src/Euterpe.Models/Charts/ChartSortField.cs
@@ -8,6 +8,6 @@ public enum ChartSortField
     Rating,
     DateAdded,
     DateUpdated,
-    DifficultyCount,
+    MapCount,
     Size
 }

--- a/src/Euterpe/Features/Charting/ChartManagePanel.axaml
+++ b/src/Euterpe/Features/Charting/ChartManagePanel.axaml
@@ -81,21 +81,21 @@
                 SelectedIndex="{Binding SortField}"
                 ToolTip.Tip="{Localize {x:Static loc:XAMLLiteral.ChartManage_SortBy}}">
                 <ComboBoxItem
-                    Content="{Localize {x:Static loc:XAMLLiteral.ChartManage_Sort_Name}}" />
+                    Content="{Localize {x:Static loc:XAMLLiteral.ChartSortField_Name}}" />
                 <ComboBoxItem
-                    Content="{Localize {x:Static loc:XAMLLiteral.ModInfo_Author}}" />
+                    Content="{Localize {x:Static loc:XAMLLiteral.ChartSortField_Author}}" />
                 <ComboBoxItem
-                    Content="{Localize {x:Static loc:XAMLLiteral.ChartManage_Bpm}}" />
+                    Content="{Localize {x:Static loc:XAMLLiteral.ChartSortField_Bpm}}" />
                 <ComboBoxItem
-                    Content="{Localize {x:Static loc:XAMLLiteral.ChartManage_Rating}}" />
+                    Content="{Localize {x:Static loc:XAMLLiteral.ChartSortField_Rating}}" />
                 <ComboBoxItem
-                    Content="{Localize {x:Static loc:XAMLLiteral.ChartManage_Sort_DateAdded}}" />
+                    Content="{Localize {x:Static loc:XAMLLiteral.ChartSortField_DateAdded}}" />
                 <ComboBoxItem
-                    Content="{Localize {x:Static loc:XAMLLiteral.ChartManage_Sort_DateUpdated}}" />
+                    Content="{Localize {x:Static loc:XAMLLiteral.ChartSortField_DateUpdated}}" />
                 <ComboBoxItem
-                    Content="{Localize {x:Static loc:XAMLLiteral.ChartManage_Sort_Maps}}" />
+                    Content="{Localize {x:Static loc:XAMLLiteral.ChartSortField_MapCount}}" />
                 <ComboBoxItem
-                    Content="{Localize {x:Static loc:XAMLLiteral.ChartManage_Sort_FileSize}}" />
+                    Content="{Localize {x:Static loc:XAMLLiteral.ChartSortField_Size}}" />
             </ComboBox>
 
             <ToggleButton

--- a/src/Euterpe/Features/Charting/ChartManagePanelViewModel.cs
+++ b/src/Euterpe/Features/Charting/ChartManagePanelViewModel.cs
@@ -263,7 +263,7 @@ public sealed partial class ChartManagePanelViewModel : ViewModelBase
             ChartSortField.Rating => (a, b) => a.MaxRating.CompareTo(b.MaxRating),
             ChartSortField.DateAdded => (a, b) => (a.Manifest.Meta.CreatedAt ?? 0).CompareTo(b.Manifest.Meta.CreatedAt ?? 0),
             ChartSortField.DateUpdated => (a, b) => (a.Manifest.Meta.UpdatedAt ?? 0).CompareTo(b.Manifest.Meta.UpdatedAt ?? 0),
-            ChartSortField.DifficultyCount => (a, b) => a.Difficulties.Count.CompareTo(b.Difficulties.Count),
+            ChartSortField.MapCount => (a, b) => a.Difficulties.Count.CompareTo(b.Difficulties.Count),
             ChartSortField.Size => (a, b) => a.SizeBytes.CompareTo(b.SizeBytes),
             _ => (a, b) => string.Compare(a.Manifest.Meta.Name, b.Manifest.Meta.Name, StringComparison.OrdinalIgnoreCase)
         };

--- a/tests/Euterpe.Tests/Core/Services/AudioPlayerService/ResilientSoundDataProviderTest.cs
+++ b/tests/Euterpe.Tests/Core/Services/AudioPlayerService/ResilientSoundDataProviderTest.cs
@@ -1,0 +1,71 @@
+using SoundFlow.Enums;
+using SoundFlow.Interfaces;
+using SoundFlow.Metadata.Models;
+using TUnit.Mocks.Logging;
+
+namespace Euterpe.Tests;
+
+[Category("ResilientSoundDataProviderTests")]
+[TestSubject(typeof(ResilientSoundDataProvider))]
+public sealed class ResilientSoundDataProviderTest
+{
+    private static ResilientSoundDataProvider CreateProvider(FakeSoundDataProvider inner) =>
+        new(inner, Mock.Logger<AudioPlayerService>());
+
+    [Test]
+    public async Task ReadBytes_InnerSucceeds_PassesThrough()
+    {
+        var inner = new FakeSoundDataProvider { SamplesPerRead = 16 };
+        var provider = CreateProvider(inner);
+
+        var read = provider.ReadBytes(new float[32]);
+
+        await Assert.That(read).IsEqualTo(16);
+    }
+
+    [Test]
+    public async Task ReadBytes_InnerThrows_ReturnsZeroAndStopsRetrying()
+    {
+        var inner = new FakeSoundDataProvider { ShouldThrow = true };
+        var provider = CreateProvider(inner);
+        var buffer = new float[16];
+
+        var first = provider.ReadBytes(buffer);
+        var second = provider.ReadBytes(buffer);
+
+        using var _ = Assert.Multiple();
+        await Assert.That(first).IsEqualTo(0);
+        await Assert.That(second).IsEqualTo(0);
+        await Assert.That(inner.ReadCalls).IsEqualTo(1);
+    }
+
+    private sealed class FakeSoundDataProvider : ISoundDataProvider
+    {
+        public bool ShouldThrow { get; init; }
+        public int SamplesPerRead { get; init; }
+        public int ReadCalls { get; private set; }
+
+        public int Position => 0;
+        public int Length => 100;
+        public bool CanSeek => false;
+        public SampleFormat SampleFormat => SampleFormat.F32;
+        public int SampleRate => 44100;
+        public bool IsDisposed { get; private set; }
+        public SoundFormatInfo? FormatInfo => null;
+
+        public event EventHandler<EventArgs>? EndOfStreamReached { add { } remove { } }
+        public event EventHandler<PositionChangedEventArgs>? PositionChanged { add { } remove { } }
+
+        public int ReadBytes(Span<float> buffer)
+        {
+            ReadCalls++;
+            return ShouldThrow ? throw new InvalidDataException() : SamplesPerRead;
+        }
+
+        public void Seek(int offset)
+        {
+        }
+
+        public void Dispose() => IsDisposed = true;
+    }
+}

--- a/tests/Euterpe.Tests/Models/Charts/ChartDtoTest.cs
+++ b/tests/Euterpe.Tests/Models/Charts/ChartDtoTest.cs
@@ -1,0 +1,183 @@
+namespace Euterpe.Tests.Charts;
+
+[Category("ChartDtoTests")]
+[TestSubject(typeof(ChartDto))]
+public sealed class ChartDtoTest
+{
+    private static ChartDto CreateChart(
+        int? cid = null,
+        ManifestUploader? uploader = null,
+        Dictionary<string, ManifestMap>? maps = null,
+        Dictionary<string, ManifestFileEntry>? files = null,
+        ChartSource source = ChartSource.Offline,
+        int bpm = 120,
+        int? bpmMin = null,
+        int? bpmMax = null) =>
+        new()
+        {
+            FolderPath = "/charts/folder",
+            FolderName = "folder",
+            Source = source,
+            Manifest = new Manifest
+            {
+                Schema = Manifest.CurrentSchema,
+                Cid = cid,
+                Meta = new ManifestMeta
+                {
+                    Name = "song",
+                    Author = "author",
+                    Scene = "scene",
+                    Bpm = bpm,
+                    BpmMin = bpmMin,
+                    BpmMax = bpmMax,
+                    Uploader = uploader,
+                    Maps = maps ?? new()
+                },
+                Files = files ?? new()
+            }
+        };
+
+    private static ManifestMap CreateMap(string rating, params string[] charters) =>
+        new() { Rating = rating, Charters = charters };
+
+    [Test]
+    [Arguments(512L, "0.5 KB")]
+    [Arguments(5L * (1 << 20), "5 MB")]
+    [Arguments(3L * (1 << 30) / 2, "1.5 GB")]
+    public async Task SizeDisplay_TotalSize_FormatsBinaryUnits(long size, string expected)
+    {
+        var chart = CreateChart(files: new() { ["music.ogg"] = new ManifestFileEntry { Size = size } });
+
+        await Assert.That(chart.SizeDisplay).IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task SizeBytes_MultipleFiles_Sums()
+    {
+        var chart = CreateChart(files: new()
+        {
+            ["music.ogg"] = new ManifestFileEntry { Size = 300 },
+            ["map1.bms"] = new ManifestFileEntry { Size = 212 }
+        });
+
+        await Assert.That(chart.SizeBytes).IsEqualTo(512);
+    }
+
+    [Test]
+    public async Task BpmDisplay_DifferentMinMax_ShowsRange()
+    {
+        var chart = CreateChart(bpmMin: 120, bpmMax: 140);
+
+        await Assert.That(chart.BpmDisplay).IsEqualTo("120–140");
+    }
+
+    [Test]
+    public async Task BpmDisplay_EqualMinMax_ShowsSingleBpm()
+    {
+        var chart = CreateChart(bpm: 128, bpmMin: 128, bpmMax: 128);
+
+        await Assert.That(chart.BpmDisplay).IsEqualTo("128");
+    }
+
+    [Test]
+    public async Task BpmDisplay_NoRange_ShowsBpm()
+    {
+        var chart = CreateChart(bpm: 120);
+
+        await Assert.That(chart.BpmDisplay).IsEqualTo("120");
+    }
+
+    [Test]
+    public async Task CharterDisplay_DuplicateCharters_DedupesCaseInsensitive()
+    {
+        var chart = CreateChart(maps: new()
+        {
+            ["map1"] = CreateMap("8", "Alice", "Bob"),
+            ["map2"] = CreateMap("10", "alice")
+        });
+
+        await Assert.That(chart.CharterDisplay).IsEqualTo("Alice, Bob");
+    }
+
+    [Test]
+    public async Task MaxRating_PlusRating_SortsAboveBase()
+    {
+        var chart = CreateChart(maps: new()
+        {
+            ["map1"] = CreateMap("8"),
+            ["map2"] = CreateMap("11+")
+        });
+
+        await Assert.That(chart.MaxRating).IsEqualTo(11.5);
+    }
+
+    [Test]
+    public async Task MaxRating_NoMaps_IsMinusOne()
+    {
+        var chart = CreateChart();
+
+        await Assert.That(chart.MaxRating).IsEqualTo(-1);
+    }
+
+    [Test]
+    public async Task DetailUrl_WithCid_PointsToChartPage()
+    {
+        var chart = CreateChart(cid: 123);
+
+        await Assert.That(chart.DetailUrl).IsEqualTo("https://euterpe-org.com/charts/123");
+    }
+
+    [Test]
+    public async Task DetailUrl_WithoutCid_IsNull()
+    {
+        var chart = CreateChart();
+
+        await Assert.That(chart.DetailUrl).IsNull();
+    }
+
+    [Test]
+    public async Task UploaderPageUrl_WithUploader_PointsToUserCharts()
+    {
+        var chart = CreateChart(uploader: new ManifestUploader { Uid = 7, Nickname = "uploader" });
+
+        await Assert.That(chart.UploaderPageUrl).IsEqualTo("https://euterpe-org.com/users/7?tab=charts");
+    }
+
+    [Test]
+    public async Task UploaderPageUrl_WithoutUploader_IsNull()
+    {
+        var chart = CreateChart();
+
+        await Assert.That(chart.UploaderPageUrl).IsNull();
+    }
+
+    [Test]
+    [Arguments(ChartSource.Online, true)]
+    [Arguments(ChartSource.Offline, false)]
+    public async Task IsOnline_Source_MatchesOnline(ChartSource source, bool expected)
+    {
+        var chart = CreateChart(source: source);
+
+        await Assert.That(chart.IsOnline).IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task DifficultyBadges_ExistingMaps_PairDifficultyWithRating()
+    {
+        var chart = CreateChart(
+            maps: new() { ["map1"] = CreateMap("8") },
+            files: new()
+            {
+                ["map1.bms"] = new ManifestFileEntry(),
+                ["map3.bms"] = new ManifestFileEntry()
+            });
+
+        using var _ = Assert.Multiple();
+        await Assert.That(chart.Difficulties).IsEquivalentTo([ChartDifficulty.Easy, ChartDifficulty.Master], CollectionOrdering.Matching);
+        await Assert.That(chart.DifficultyBadges).IsEquivalentTo(
+        [
+            new DifficultyBadge(ChartDifficulty.Easy, "8"),
+            new DifficultyBadge(ChartDifficulty.Master, string.Empty)
+        ], CollectionOrdering.Matching);
+    }
+}

--- a/tests/Euterpe.Tests/Models/Charts/ManifestMapTest.cs
+++ b/tests/Euterpe.Tests/Models/Charts/ManifestMapTest.cs
@@ -1,0 +1,21 @@
+namespace Euterpe.Tests.Charts;
+
+[Category("ManifestMapTests")]
+[TestSubject(typeof(ManifestMap))]
+public sealed class ManifestMapTest
+{
+    [Test]
+    [Arguments("8", 8)]
+    [Arguments("12", 12)]
+    [Arguments("9.5", 9.5)]
+    [Arguments("11+", 11.5)]
+    [Arguments("", -1)]
+    [Arguments("+", -1)]
+    [Arguments("abc", -1)]
+    public async Task RatingValue_Rating_ParsesToSortValue(string rating, double expected)
+    {
+        var map = new ManifestMap { Rating = rating, Charters = [] };
+
+        await Assert.That(map.RatingValue).IsEqualTo(expected);
+    }
+}


### PR DESCRIPTION
Follow-up to #740 with the remaining commits from the review stack:

- `ChartSortField_*` localization keys following the enum-member key convention; `DifficultyCount` -> `MapCount`; the chart resx block re-homed alphabetically across all locales; sort-item value casing unified
- `MapFileName` builds its name in one interpolation
- mod version comparison promoted to a `SemVersion` string extension (C# 14 extension member)
- unit tests covering chart computed values and the resilient audio provider
- rules: modern API choice and resx key naming conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)