### PR TITLE
rework the EPK editor and reorganise the charter toolkit

### DIFF
--- a/src/Euterpe.Localization/XAML/XAML.de.resx
+++ b/src/Euterpe.Localization/XAML/XAML.de.resx
@@ -61,6 +61,30 @@
   <data name="Button_Update" xml:space="preserve">
     <value>Aktualisieren</value>
   </data>
+  <data name="ChartAnalyzer_Description" xml:space="preserve">
+    <value>Ungefähre Bewertungen vorhersagen und die Note-Aufschlüsselung eines Charts analysieren</value>
+  </data>
+  <data name="ChartAnalyzer_Title" xml:space="preserve">
+    <value>Chart Analyzer</value>
+  </data>
+  <data name="ChartSubmit_Description" xml:space="preserve">
+    <value>Lade deinen Chart hoch und veröffentliche ihn</value>
+  </data>
+  <data name="ChartSubmit_Title" xml:space="preserve">
+    <value>Chart einreichen</value>
+  </data>
+  <data name="CharterToolkit_Offline_Description" xml:space="preserve">
+    <value>Die Manifest-Metadaten eines Charts lokal bearbeiten</value>
+  </data>
+  <data name="CharterToolkit_Offline_Title" xml:space="preserve">
+    <value>Offline-Werkzeuge</value>
+  </data>
+  <data name="CharterToolkit_Online_Description" xml:space="preserve">
+    <value>Charts auf der Euterpe-Website analysieren und einreichen (öffnet im Browser)</value>
+  </data>
+  <data name="CharterToolkit_Online_Title" xml:space="preserve">
+    <value>Online-Werkzeuge</value>
+  </data>
   <data name="ChartDifficulty_Easy" xml:space="preserve">
     <value>Easy</value>
   </data>
@@ -187,38 +211,41 @@
   <data name="EpkEditor_Back" xml:space="preserve">
     <value>Zurück</value>
   </data>
-  <data name="EpkEditor_Bpm_Range" xml:space="preserve">
-    <value>Bereich</value>
+  <data name="EpkEditor_Charters_Watermark" xml:space="preserve">
+    <value>Charter hinzufügen</value>
   </data>
   <data name="EpkEditor_Field_Author" xml:space="preserve">
-    <value>Autor</value>
+    <value>Song-Autor</value>
   </data>
   <data name="EpkEditor_Field_BackgroundVideoOpacity" xml:space="preserve">
-    <value>Hintergrundvideo-Deckkraft</value>
+    <value>Video-Deckkraft</value>
   </data>
   <data name="EpkEditor_Field_Bpm" xml:space="preserve">
     <value>BPM</value>
   </data>
+  <data name="EpkEditor_Field_BpmMax" xml:space="preserve">
+    <value>Max. BPM</value>
+  </data>
+  <data name="EpkEditor_Field_BpmMin" xml:space="preserve">
+    <value>Min. BPM</value>
+  </data>
   <data name="EpkEditor_Field_Description" xml:space="preserve">
     <value>Beschreibung</value>
-  </data>
-  <data name="EpkEditor_Field_Difficulties" xml:space="preserve">
-    <value>Schwierigkeitsgrade</value>
   </data>
   <data name="EpkEditor_Field_Files" xml:space="preserve">
     <value>Dateien</value>
   </data>
   <data name="EpkEditor_Field_HideMessage" xml:space="preserve">
-    <value>Versteckt-Meldung</value>
+    <value>Meldung</value>
   </data>
   <data name="EpkEditor_Field_HideMode" xml:space="preserve">
-    <value>Versteckt-Modus</value>
+    <value>Modus</value>
   </data>
   <data name="EpkEditor_Field_HideRatingOverride" xml:space="preserve">
-    <value>Bewertungsüberschreibung (Versteckt)</value>
+    <value>Anzeige der Bewertung überschreiben</value>
   </data>
   <data name="EpkEditor_Field_Name" xml:space="preserve">
-    <value>Name</value>
+    <value>Chart-Name</value>
   </data>
   <data name="EpkEditor_Field_NameRomanized" xml:space="preserve">
     <value>Romanisierter Name</value>
@@ -235,29 +262,62 @@
   <data name="EpkEditor_Field_SearchKeywords" xml:space="preserve">
     <value>Suchbegriffe</value>
   </data>
-  <data name="EpkEditor_Field_SearchKeywords_Description" xml:space="preserve">
-    <value>Suchbegriffe mit Kommas trennen</value>
+  <data name="EpkEditor_Field_TempoVariable" xml:space="preserve">
+    <value>Variables Tempo</value>
   </data>
   <data name="EpkEditor_Files_Refresh" xml:space="preserve">
     <value>Aktualisieren</value>
   </data>
+  <data name="EpkEditor_Files_Summary" xml:space="preserve">
+    <value>{0} Dateien · {1}</value>
+  </data>
+  <data name="EpkEditor_Hint_Required" xml:space="preserve">
+    <value>Fülle alle Pflichtfelder aus, um zu speichern</value>
+  </data>
+  <data name="EpkEditor_Hint_TempoRange" xml:space="preserve">
+    <value>Lege einen gültigen Tempobereich fest (Min ≤ Max)</value>
+  </data>
+  <data name="EpkEditor_Keywords_Watermark" xml:space="preserve">
+    <value>Suchbegriff hinzufügen</value>
+  </data>
   <data name="EpkEditor_Launcher_Description" xml:space="preserve">
-    <value>Metadaten der manifest.epk eines Charts öffnen und bearbeiten</value>
-  </data>
-  <data name="EpkEditor_Launcher_Title" xml:space="preserve">
-    <value>EPK-Metadaten-Editor</value>
-  </data>
-  <data name="EpkEditor_Map_Charters" xml:space="preserve">
-    <value>Charters</value>
+    <value>Die manifest.epk eines Charts öffnen und ihre Metadaten bearbeiten</value>
   </data>
   <data name="EpkEditor_Map_Rating" xml:space="preserve">
     <value>Bewertung</value>
   </data>
+  <data name="EpkEditor_MissingFiles" xml:space="preserve">
+    <value>{0} von diesem Chart referenzierte Datei(en) fehlen in seinem Ordner</value>
+  </data>
+  <data name="EpkEditor_NewFile" xml:space="preserve">
+    <value>Neue EPK …</value>
+  </data>
+  <data name="EpkEditor_New_Description" xml:space="preserve">
+    <value>Einen neuen Chart aus einem Ordner mit Assets erstellen</value>
+  </data>
   <data name="EpkEditor_OpenFile" xml:space="preserve">
     <value>EPK-Datei öffnen…</value>
   </data>
+  <data name="EpkEditor_OpenFolder" xml:space="preserve">
+    <value>Ordner öffnen</value>
+  </data>
   <data name="EpkEditor_Save" xml:space="preserve">
     <value>Speichern</value>
+  </data>
+  <data name="EpkEditor_Section_ChartInfo" xml:space="preserve">
+    <value>Chart-Infos</value>
+  </data>
+  <data name="EpkEditor_Section_Discovery" xml:space="preserve">
+    <value>Beschreibung &amp; Auffindbarkeit</value>
+  </data>
+  <data name="EpkEditor_Section_HiddenMode" xml:space="preserve">
+    <value>Versteckte Schwierigkeit</value>
+  </data>
+  <data name="EpkEditor_Section_Identity" xml:space="preserve">
+    <value>Basisinfos</value>
+  </data>
+  <data name="EpkEditor_Section_Maps" xml:space="preserve">
+    <value>Maps</value>
   </data>
   <data name="Folder_AppLogs" xml:space="preserve">
     <value>App-Protokolle</value>

--- a/src/Euterpe.Localization/XAML/XAML.es.resx
+++ b/src/Euterpe.Localization/XAML/XAML.es.resx
@@ -61,6 +61,30 @@
   <data name="Button_Update" xml:space="preserve">
     <value>Actualizar</value>
   </data>
+  <data name="ChartAnalyzer_Description" xml:space="preserve">
+    <value>Predice valoraciones aproximadas y analiza el desglose de Note de un chart</value>
+  </data>
+  <data name="ChartAnalyzer_Title" xml:space="preserve">
+    <value>Chart Analyzer</value>
+  </data>
+  <data name="ChartSubmit_Description" xml:space="preserve">
+    <value>Sube y publica tu chart</value>
+  </data>
+  <data name="ChartSubmit_Title" xml:space="preserve">
+    <value>Enviar chart</value>
+  </data>
+  <data name="CharterToolkit_Offline_Description" xml:space="preserve">
+    <value>Edita localmente los metadatos del manifest de un chart</value>
+  </data>
+  <data name="CharterToolkit_Offline_Title" xml:space="preserve">
+    <value>Herramientas offline</value>
+  </data>
+  <data name="CharterToolkit_Online_Description" xml:space="preserve">
+    <value>Analiza y envía charts en el sitio de Euterpe (se abre en tu navegador)</value>
+  </data>
+  <data name="CharterToolkit_Online_Title" xml:space="preserve">
+    <value>Herramientas online</value>
+  </data>
   <data name="ChartDifficulty_Easy" xml:space="preserve">
     <value>Fácil</value>
   </data>
@@ -187,44 +211,47 @@
   <data name="EpkEditor_Back" xml:space="preserve">
     <value>Atrás</value>
   </data>
-  <data name="EpkEditor_Bpm_Range" xml:space="preserve">
-    <value>Rango</value>
+  <data name="EpkEditor_Charters_Watermark" xml:space="preserve">
+    <value>Añadir un charter</value>
   </data>
   <data name="EpkEditor_Field_Author" xml:space="preserve">
-    <value>Autor</value>
+    <value>Autor de la canción</value>
   </data>
   <data name="EpkEditor_Field_BackgroundVideoOpacity" xml:space="preserve">
-    <value>Opacidad del vídeo de fondo</value>
+    <value>Opacidad del vídeo</value>
   </data>
   <data name="EpkEditor_Field_Bpm" xml:space="preserve">
     <value>BPM</value>
   </data>
+  <data name="EpkEditor_Field_BpmMax" xml:space="preserve">
+    <value>BPM máx.</value>
+  </data>
+  <data name="EpkEditor_Field_BpmMin" xml:space="preserve">
+    <value>BPM mín.</value>
+  </data>
   <data name="EpkEditor_Field_Description" xml:space="preserve">
     <value>Descripción</value>
-  </data>
-  <data name="EpkEditor_Field_Difficulties" xml:space="preserve">
-    <value>Dificultades</value>
   </data>
   <data name="EpkEditor_Field_Files" xml:space="preserve">
     <value>Archivos</value>
   </data>
   <data name="EpkEditor_Field_HideMessage" xml:space="preserve">
-    <value>Ocultar mensaje</value>
+    <value>Mensaje</value>
   </data>
   <data name="EpkEditor_Field_HideMode" xml:space="preserve">
-    <value>Ocultar modo</value>
+    <value>Modo</value>
   </data>
   <data name="EpkEditor_Field_HideRatingOverride" xml:space="preserve">
-    <value>Ocultar anulación de nivel</value>
+    <value>Anulación de nivel mostrado</value>
   </data>
   <data name="EpkEditor_Field_Name" xml:space="preserve">
-    <value>Nombre</value>
+    <value>Nombre del chart</value>
   </data>
   <data name="EpkEditor_Field_NameRomanized" xml:space="preserve">
     <value>Nombre romanizado</value>
   </data>
   <data name="EpkEditor_Field_SafeForStreamer" xml:space="preserve">
-    <value>Apto para streaming</value>
+    <value>Apto para streamers</value>
   </data>
   <data name="EpkEditor_Field_Scene" xml:space="preserve">
     <value>Escena</value>
@@ -235,29 +262,62 @@
   <data name="EpkEditor_Field_SearchKeywords" xml:space="preserve">
     <value>Palabras clave de búsqueda</value>
   </data>
-  <data name="EpkEditor_Field_SearchKeywords_Description" xml:space="preserve">
-    <value>Separa las palabras clave con comas</value>
+  <data name="EpkEditor_Field_TempoVariable" xml:space="preserve">
+    <value>Tempo variable</value>
   </data>
   <data name="EpkEditor_Files_Refresh" xml:space="preserve">
     <value>Actualizar</value>
   </data>
+  <data name="EpkEditor_Files_Summary" xml:space="preserve">
+    <value>{0} archivos · {1}</value>
+  </data>
+  <data name="EpkEditor_Hint_Required" xml:space="preserve">
+    <value>Rellena todos los campos obligatorios para guardar</value>
+  </data>
+  <data name="EpkEditor_Hint_TempoRange" xml:space="preserve">
+    <value>Define un rango de tempo válido (mín ≤ máx)</value>
+  </data>
+  <data name="EpkEditor_Keywords_Watermark" xml:space="preserve">
+    <value>Añadir una palabra clave</value>
+  </data>
   <data name="EpkEditor_Launcher_Description" xml:space="preserve">
     <value>Abre y edita los metadatos del manifest.epk de un chart</value>
-  </data>
-  <data name="EpkEditor_Launcher_Title" xml:space="preserve">
-    <value>Editor de metadatos EPK</value>
-  </data>
-  <data name="EpkEditor_Map_Charters" xml:space="preserve">
-    <value>Charters</value>
   </data>
   <data name="EpkEditor_Map_Rating" xml:space="preserve">
     <value>Nivel</value>
   </data>
+  <data name="EpkEditor_MissingFiles" xml:space="preserve">
+    <value>Faltan {0} archivo(s) referenciados por este chart en su carpeta</value>
+  </data>
+  <data name="EpkEditor_NewFile" xml:space="preserve">
+    <value>Nuevo EPK…</value>
+  </data>
+  <data name="EpkEditor_New_Description" xml:space="preserve">
+    <value>Crea un chart nuevo a partir de una carpeta de recursos</value>
+  </data>
   <data name="EpkEditor_OpenFile" xml:space="preserve">
     <value>Abrir archivo EPK…</value>
   </data>
+  <data name="EpkEditor_OpenFolder" xml:space="preserve">
+    <value>Abrir carpeta</value>
+  </data>
   <data name="EpkEditor_Save" xml:space="preserve">
     <value>Guardar</value>
+  </data>
+  <data name="EpkEditor_Section_ChartInfo" xml:space="preserve">
+    <value>Información del chart</value>
+  </data>
+  <data name="EpkEditor_Section_Discovery" xml:space="preserve">
+    <value>Descripción y descubrimiento</value>
+  </data>
+  <data name="EpkEditor_Section_HiddenMode" xml:space="preserve">
+    <value>Dificultad oculta</value>
+  </data>
+  <data name="EpkEditor_Section_Identity" xml:space="preserve">
+    <value>Información básica</value>
+  </data>
+  <data name="EpkEditor_Section_Maps" xml:space="preserve">
+    <value>Mapas</value>
   </data>
   <data name="Folder_AppLogs" xml:space="preserve">
     <value>Registros de la app</value>

--- a/src/Euterpe.Localization/XAML/XAML.fr.resx
+++ b/src/Euterpe.Localization/XAML/XAML.fr.resx
@@ -61,6 +61,30 @@
   <data name="Button_Update" xml:space="preserve">
     <value>Mettre à jour</value>
   </data>
+  <data name="ChartAnalyzer_Description" xml:space="preserve">
+    <value>Prédit des niveaux approximatifs et analyse la répartition des Note d'un chart</value>
+  </data>
+  <data name="ChartAnalyzer_Title" xml:space="preserve">
+    <value>Chart Analyzer</value>
+  </data>
+  <data name="ChartSubmit_Description" xml:space="preserve">
+    <value>Téléversez et publiez votre chart</value>
+  </data>
+  <data name="ChartSubmit_Title" xml:space="preserve">
+    <value>Soumettre le chart</value>
+  </data>
+  <data name="CharterToolkit_Offline_Description" xml:space="preserve">
+    <value>Modifier localement les métadonnées du manifest d'un chart</value>
+  </data>
+  <data name="CharterToolkit_Offline_Title" xml:space="preserve">
+    <value>Outils hors ligne</value>
+  </data>
+  <data name="CharterToolkit_Online_Description" xml:space="preserve">
+    <value>Analysez et soumettez des charts sur le site Euterpe (s'ouvre dans votre navigateur)</value>
+  </data>
+  <data name="CharterToolkit_Online_Title" xml:space="preserve">
+    <value>Outils en ligne</value>
+  </data>
   <data name="ChartDifficulty_Easy" xml:space="preserve">
     <value>Easy</value>
   </data>
@@ -187,44 +211,47 @@
   <data name="EpkEditor_Back" xml:space="preserve">
     <value>Retour</value>
   </data>
-  <data name="EpkEditor_Bpm_Range" xml:space="preserve">
-    <value>Plage</value>
+  <data name="EpkEditor_Charters_Watermark" xml:space="preserve">
+    <value>Ajouter un charteur</value>
   </data>
   <data name="EpkEditor_Field_Author" xml:space="preserve">
-    <value>Auteur</value>
+    <value>Auteur du morceau</value>
   </data>
   <data name="EpkEditor_Field_BackgroundVideoOpacity" xml:space="preserve">
-    <value>Opacité de la vidéo d'arrière-plan</value>
+    <value>Opacité de la vidéo</value>
   </data>
   <data name="EpkEditor_Field_Bpm" xml:space="preserve">
     <value>BPM</value>
   </data>
+  <data name="EpkEditor_Field_BpmMax" xml:space="preserve">
+    <value>BPM max</value>
+  </data>
+  <data name="EpkEditor_Field_BpmMin" xml:space="preserve">
+    <value>BPM min</value>
+  </data>
   <data name="EpkEditor_Field_Description" xml:space="preserve">
     <value>Description</value>
-  </data>
-  <data name="EpkEditor_Field_Difficulties" xml:space="preserve">
-    <value>Difficultés</value>
   </data>
   <data name="EpkEditor_Field_Files" xml:space="preserve">
     <value>Fichiers</value>
   </data>
   <data name="EpkEditor_Field_HideMessage" xml:space="preserve">
-    <value>Message (mode caché)</value>
+    <value>Message</value>
   </data>
   <data name="EpkEditor_Field_HideMode" xml:space="preserve">
-    <value>Mode caché</value>
+    <value>Mode</value>
   </data>
   <data name="EpkEditor_Field_HideRatingOverride" xml:space="preserve">
-    <value>Niveau alternatif</value>
+    <value>Niveau affiché alternatif</value>
   </data>
   <data name="EpkEditor_Field_Name" xml:space="preserve">
-    <value>Nom</value>
+    <value>Nom du chart</value>
   </data>
   <data name="EpkEditor_Field_NameRomanized" xml:space="preserve">
     <value>Nom romanisé</value>
   </data>
   <data name="EpkEditor_Field_SafeForStreamer" xml:space="preserve">
-    <value>Sûr pour le streaming</value>
+    <value>Sûr pour les streamers</value>
   </data>
   <data name="EpkEditor_Field_Scene" xml:space="preserve">
     <value>Scène</value>
@@ -235,29 +262,62 @@
   <data name="EpkEditor_Field_SearchKeywords" xml:space="preserve">
     <value>Mots-clés de recherche</value>
   </data>
-  <data name="EpkEditor_Field_SearchKeywords_Description" xml:space="preserve">
-    <value>Séparez les mots-clés par des virgules</value>
+  <data name="EpkEditor_Field_TempoVariable" xml:space="preserve">
+    <value>Tempo variable</value>
   </data>
   <data name="EpkEditor_Files_Refresh" xml:space="preserve">
     <value>Actualiser</value>
   </data>
+  <data name="EpkEditor_Files_Summary" xml:space="preserve">
+    <value>{0} fichiers · {1}</value>
+  </data>
+  <data name="EpkEditor_Hint_Required" xml:space="preserve">
+    <value>Remplissez tous les champs obligatoires pour enregistrer</value>
+  </data>
+  <data name="EpkEditor_Hint_TempoRange" xml:space="preserve">
+    <value>Définissez une plage de tempo valide (min ≤ max)</value>
+  </data>
+  <data name="EpkEditor_Keywords_Watermark" xml:space="preserve">
+    <value>Ajouter un mot-clé</value>
+  </data>
   <data name="EpkEditor_Launcher_Description" xml:space="preserve">
     <value>Ouvrir et modifier les métadonnées du manifest.epk d'un chart</value>
-  </data>
-  <data name="EpkEditor_Launcher_Title" xml:space="preserve">
-    <value>Éditeur de métadonnées EPK</value>
-  </data>
-  <data name="EpkEditor_Map_Charters" xml:space="preserve">
-    <value>Charteurs</value>
   </data>
   <data name="EpkEditor_Map_Rating" xml:space="preserve">
     <value>Niveau</value>
   </data>
+  <data name="EpkEditor_MissingFiles" xml:space="preserve">
+    <value>{0} fichier(s) référencé(s) par ce chart sont absents de son dossier</value>
+  </data>
+  <data name="EpkEditor_NewFile" xml:space="preserve">
+    <value>Nouveau EPK…</value>
+  </data>
+  <data name="EpkEditor_New_Description" xml:space="preserve">
+    <value>Créer un chart à partir d'un dossier de ressources</value>
+  </data>
   <data name="EpkEditor_OpenFile" xml:space="preserve">
     <value>Ouvrir un fichier EPK…</value>
   </data>
+  <data name="EpkEditor_OpenFolder" xml:space="preserve">
+    <value>Ouvrir le dossier</value>
+  </data>
   <data name="EpkEditor_Save" xml:space="preserve">
     <value>Enregistrer</value>
+  </data>
+  <data name="EpkEditor_Section_ChartInfo" xml:space="preserve">
+    <value>Infos du chart</value>
+  </data>
+  <data name="EpkEditor_Section_Discovery" xml:space="preserve">
+    <value>Description et découverte</value>
+  </data>
+  <data name="EpkEditor_Section_HiddenMode" xml:space="preserve">
+    <value>Difficulté cachée</value>
+  </data>
+  <data name="EpkEditor_Section_Identity" xml:space="preserve">
+    <value>Infos de base</value>
+  </data>
+  <data name="EpkEditor_Section_Maps" xml:space="preserve">
+    <value>Maps</value>
   </data>
   <data name="Folder_AppLogs" xml:space="preserve">
     <value>Journaux de l'appli</value>

--- a/src/Euterpe.Localization/XAML/XAML.hr.resx
+++ b/src/Euterpe.Localization/XAML/XAML.hr.resx
@@ -61,6 +61,30 @@
   <data name="Button_Update" xml:space="preserve">
     <value>Ažuriraj</value>
   </data>
+  <data name="ChartAnalyzer_Description" xml:space="preserve">
+    <value>Predvidi približne razine i analiziraj raspodjelu Note u chartu</value>
+  </data>
+  <data name="ChartAnalyzer_Title" xml:space="preserve">
+    <value>Chart Analyzer</value>
+  </data>
+  <data name="ChartSubmit_Description" xml:space="preserve">
+    <value>Prenesi i objavi svoj chart</value>
+  </data>
+  <data name="ChartSubmit_Title" xml:space="preserve">
+    <value>Pošalji chart</value>
+  </data>
+  <data name="CharterToolkit_Offline_Description" xml:space="preserve">
+    <value>Uredi metapodatke manifesta charta lokalno</value>
+  </data>
+  <data name="CharterToolkit_Offline_Title" xml:space="preserve">
+    <value>Offline alati</value>
+  </data>
+  <data name="CharterToolkit_Online_Description" xml:space="preserve">
+    <value>Analiziraj i pošalji chartove na Euterpe stranici (otvara se u pregledniku)</value>
+  </data>
+  <data name="CharterToolkit_Online_Title" xml:space="preserve">
+    <value>Online alati</value>
+  </data>
   <data name="ChartDifficulty_Easy" xml:space="preserve">
     <value>Easy</value>
   </data>
@@ -187,38 +211,41 @@
   <data name="EpkEditor_Back" xml:space="preserve">
     <value>Natrag</value>
   </data>
-  <data name="EpkEditor_Bpm_Range" xml:space="preserve">
-    <value>Raspon</value>
+  <data name="EpkEditor_Charters_Watermark" xml:space="preserve">
+    <value>Dodaj kreatora charta</value>
   </data>
   <data name="EpkEditor_Field_Author" xml:space="preserve">
-    <value>Autor</value>
+    <value>Autor pjesme</value>
   </data>
   <data name="EpkEditor_Field_BackgroundVideoOpacity" xml:space="preserve">
-    <value>Prozirnost pozadinskog videozapisa</value>
+    <value>Prozirnost videozapisa</value>
   </data>
   <data name="EpkEditor_Field_Bpm" xml:space="preserve">
     <value>BPM</value>
   </data>
+  <data name="EpkEditor_Field_BpmMax" xml:space="preserve">
+    <value>Maks. BPM</value>
+  </data>
+  <data name="EpkEditor_Field_BpmMin" xml:space="preserve">
+    <value>Min. BPM</value>
+  </data>
   <data name="EpkEditor_Field_Description" xml:space="preserve">
     <value>Opis</value>
-  </data>
-  <data name="EpkEditor_Field_Difficulties" xml:space="preserve">
-    <value>Težine</value>
   </data>
   <data name="EpkEditor_Field_Files" xml:space="preserve">
     <value>Datoteke</value>
   </data>
   <data name="EpkEditor_Field_HideMessage" xml:space="preserve">
-    <value>Sakrij poruku</value>
+    <value>Poruka</value>
   </data>
   <data name="EpkEditor_Field_HideMode" xml:space="preserve">
-    <value>Sakrij način rada</value>
+    <value>Način rada</value>
   </data>
   <data name="EpkEditor_Field_HideRatingOverride" xml:space="preserve">
-    <value>Sakrij nadjačavanje razine</value>
+    <value>Nadjačavanje prikaza razine</value>
   </data>
   <data name="EpkEditor_Field_Name" xml:space="preserve">
-    <value>Naziv</value>
+    <value>Naziv charta</value>
   </data>
   <data name="EpkEditor_Field_NameRomanized" xml:space="preserve">
     <value>Romanizirani naziv</value>
@@ -235,29 +262,62 @@
   <data name="EpkEditor_Field_SearchKeywords" xml:space="preserve">
     <value>Ključne riječi za pretragu</value>
   </data>
-  <data name="EpkEditor_Field_SearchKeywords_Description" xml:space="preserve">
-    <value>Odvojite ključne riječi zarezima</value>
+  <data name="EpkEditor_Field_TempoVariable" xml:space="preserve">
+    <value>Promjenjivi tempo</value>
   </data>
   <data name="EpkEditor_Files_Refresh" xml:space="preserve">
     <value>Osvježi</value>
   </data>
+  <data name="EpkEditor_Files_Summary" xml:space="preserve">
+    <value>{0} datoteka · {1}</value>
+  </data>
+  <data name="EpkEditor_Hint_Required" xml:space="preserve">
+    <value>Ispunite sva obavezna polja za spremanje</value>
+  </data>
+  <data name="EpkEditor_Hint_TempoRange" xml:space="preserve">
+    <value>Postavite valjan raspon tempa (min ≤ maks)</value>
+  </data>
+  <data name="EpkEditor_Keywords_Watermark" xml:space="preserve">
+    <value>Dodaj ključnu riječ</value>
+  </data>
   <data name="EpkEditor_Launcher_Description" xml:space="preserve">
     <value>Otvori i uredi metapodatke datoteke manifest.epk charta</value>
-  </data>
-  <data name="EpkEditor_Launcher_Title" xml:space="preserve">
-    <value>EPK uređivač metapodataka</value>
-  </data>
-  <data name="EpkEditor_Map_Charters" xml:space="preserve">
-    <value>Kreatori chartova</value>
   </data>
   <data name="EpkEditor_Map_Rating" xml:space="preserve">
     <value>Razina</value>
   </data>
+  <data name="EpkEditor_MissingFiles" xml:space="preserve">
+    <value>{0} datoteka na koje ovaj chart upućuje nedostaje u njegovoj mapi</value>
+  </data>
+  <data name="EpkEditor_NewFile" xml:space="preserve">
+    <value>Novi EPK…</value>
+  </data>
+  <data name="EpkEditor_New_Description" xml:space="preserve">
+    <value>Izgradi novi chart iz mape s resursima</value>
+  </data>
   <data name="EpkEditor_OpenFile" xml:space="preserve">
     <value>Otvori EPK datoteku…</value>
   </data>
+  <data name="EpkEditor_OpenFolder" xml:space="preserve">
+    <value>Otvori mapu</value>
+  </data>
   <data name="EpkEditor_Save" xml:space="preserve">
     <value>Spremi</value>
+  </data>
+  <data name="EpkEditor_Section_ChartInfo" xml:space="preserve">
+    <value>Informacije o chartu</value>
+  </data>
+  <data name="EpkEditor_Section_Discovery" xml:space="preserve">
+    <value>Opis i otkrivanje</value>
+  </data>
+  <data name="EpkEditor_Section_HiddenMode" xml:space="preserve">
+    <value>Skrivena težina</value>
+  </data>
+  <data name="EpkEditor_Section_Identity" xml:space="preserve">
+    <value>Osnovne informacije</value>
+  </data>
+  <data name="EpkEditor_Section_Maps" xml:space="preserve">
+    <value>Mape</value>
   </data>
   <data name="Folder_AppLogs" xml:space="preserve">
     <value>Zapisnici aplikacije</value>

--- a/src/Euterpe.Localization/XAML/XAML.hu.resx
+++ b/src/Euterpe.Localization/XAML/XAML.hu.resx
@@ -61,6 +61,30 @@
   <data name="Button_Update" xml:space="preserve">
     <value>Frissítés</value>
   </data>
+  <data name="ChartAnalyzer_Description" xml:space="preserve">
+    <value>Hozzávetőleges szintek megjóslása és a chart Note-eloszlásának elemzése</value>
+  </data>
+  <data name="ChartAnalyzer_Title" xml:space="preserve">
+    <value>Chart Analyzer</value>
+  </data>
+  <data name="ChartSubmit_Description" xml:space="preserve">
+    <value>Töltsd fel és tedd közzé a chartodat</value>
+  </data>
+  <data name="ChartSubmit_Title" xml:space="preserve">
+    <value>Chart beküldése</value>
+  </data>
+  <data name="CharterToolkit_Offline_Description" xml:space="preserve">
+    <value>Egy chart manifest metaadatainak helyi szerkesztése</value>
+  </data>
+  <data name="CharterToolkit_Offline_Title" xml:space="preserve">
+    <value>Offline eszközök</value>
+  </data>
+  <data name="CharterToolkit_Online_Description" xml:space="preserve">
+    <value>Chartek elemzése és beküldése az Euterpe oldalon (a böngészőben nyílik meg)</value>
+  </data>
+  <data name="CharterToolkit_Online_Title" xml:space="preserve">
+    <value>Online eszközök</value>
+  </data>
   <data name="ChartDifficulty_Easy" xml:space="preserve">
     <value>Könnyű</value>
   </data>
@@ -187,38 +211,41 @@
   <data name="EpkEditor_Back" xml:space="preserve">
     <value>Vissza</value>
   </data>
-  <data name="EpkEditor_Bpm_Range" xml:space="preserve">
-    <value>Tartomány</value>
+  <data name="EpkEditor_Charters_Watermark" xml:space="preserve">
+    <value>Charter hozzáadása</value>
   </data>
   <data name="EpkEditor_Field_Author" xml:space="preserve">
-    <value>Szerző</value>
+    <value>Dal szerzője</value>
   </data>
   <data name="EpkEditor_Field_BackgroundVideoOpacity" xml:space="preserve">
-    <value>Háttérvideó átlátszósága</value>
+    <value>Videó átlátszósága</value>
   </data>
   <data name="EpkEditor_Field_Bpm" xml:space="preserve">
     <value>BPM</value>
   </data>
+  <data name="EpkEditor_Field_BpmMax" xml:space="preserve">
+    <value>Max. BPM</value>
+  </data>
+  <data name="EpkEditor_Field_BpmMin" xml:space="preserve">
+    <value>Min. BPM</value>
+  </data>
   <data name="EpkEditor_Field_Description" xml:space="preserve">
     <value>Leírás</value>
-  </data>
-  <data name="EpkEditor_Field_Difficulties" xml:space="preserve">
-    <value>Nehézségek</value>
   </data>
   <data name="EpkEditor_Field_Files" xml:space="preserve">
     <value>Fájlok</value>
   </data>
   <data name="EpkEditor_Field_HideMessage" xml:space="preserve">
-    <value>Rejtett üzenet</value>
+    <value>Üzenet</value>
   </data>
   <data name="EpkEditor_Field_HideMode" xml:space="preserve">
-    <value>Rejtett mód</value>
+    <value>Mód</value>
   </data>
   <data name="EpkEditor_Field_HideRatingOverride" xml:space="preserve">
-    <value>Szint felülírás elrejtése</value>
+    <value>Szint megjelenítésének felülírása</value>
   </data>
   <data name="EpkEditor_Field_Name" xml:space="preserve">
-    <value>Név</value>
+    <value>Chart neve</value>
   </data>
   <data name="EpkEditor_Field_NameRomanized" xml:space="preserve">
     <value>Romanizált név</value>
@@ -235,29 +262,62 @@
   <data name="EpkEditor_Field_SearchKeywords" xml:space="preserve">
     <value>Keresési kulcsszavak</value>
   </data>
-  <data name="EpkEditor_Field_SearchKeywords_Description" xml:space="preserve">
-    <value>Kulcsszavak vesszővel elválasztva</value>
+  <data name="EpkEditor_Field_TempoVariable" xml:space="preserve">
+    <value>Változó tempó</value>
   </data>
   <data name="EpkEditor_Files_Refresh" xml:space="preserve">
     <value>Frissítés</value>
   </data>
+  <data name="EpkEditor_Files_Summary" xml:space="preserve">
+    <value>{0} fájl · {1}</value>
+  </data>
+  <data name="EpkEditor_Hint_Required" xml:space="preserve">
+    <value>A mentéshez töltsd ki az összes kötelező mezőt</value>
+  </data>
+  <data name="EpkEditor_Hint_TempoRange" xml:space="preserve">
+    <value>Adj meg érvényes tempótartományt (min ≤ max)</value>
+  </data>
+  <data name="EpkEditor_Keywords_Watermark" xml:space="preserve">
+    <value>Kulcsszó hozzáadása</value>
+  </data>
   <data name="EpkEditor_Launcher_Description" xml:space="preserve">
     <value>Chart manifest.epk metaadatainak megnyitása és szerkesztése</value>
-  </data>
-  <data name="EpkEditor_Launcher_Title" xml:space="preserve">
-    <value>EPK Metaadat-szerkesztő</value>
-  </data>
-  <data name="EpkEditor_Map_Charters" xml:space="preserve">
-    <value>Charterek</value>
   </data>
   <data name="EpkEditor_Map_Rating" xml:space="preserve">
     <value>Szint</value>
   </data>
+  <data name="EpkEditor_MissingFiles" xml:space="preserve">
+    <value>{0} fájl, amelyre ez a chart hivatkozik, hiányzik a mappájából</value>
+  </data>
+  <data name="EpkEditor_NewFile" xml:space="preserve">
+    <value>Új EPK…</value>
+  </data>
+  <data name="EpkEditor_New_Description" xml:space="preserve">
+    <value>Új chart építése egy mappányi eszközből</value>
+  </data>
   <data name="EpkEditor_OpenFile" xml:space="preserve">
     <value>EPK fájl megnyitása…</value>
   </data>
+  <data name="EpkEditor_OpenFolder" xml:space="preserve">
+    <value>Mappa megnyitása</value>
+  </data>
   <data name="EpkEditor_Save" xml:space="preserve">
     <value>Mentés</value>
+  </data>
+  <data name="EpkEditor_Section_ChartInfo" xml:space="preserve">
+    <value>Chart-információk</value>
+  </data>
+  <data name="EpkEditor_Section_Discovery" xml:space="preserve">
+    <value>Leírás és felfedezés</value>
+  </data>
+  <data name="EpkEditor_Section_HiddenMode" xml:space="preserve">
+    <value>Rejtett nehézség</value>
+  </data>
+  <data name="EpkEditor_Section_Identity" xml:space="preserve">
+    <value>Alapadatok</value>
+  </data>
+  <data name="EpkEditor_Section_Maps" xml:space="preserve">
+    <value>Mapek</value>
   </data>
   <data name="Folder_AppLogs" xml:space="preserve">
     <value>Alkalmazásnaplók</value>

--- a/src/Euterpe.Localization/XAML/XAML.id.resx
+++ b/src/Euterpe.Localization/XAML/XAML.id.resx
@@ -61,6 +61,30 @@
   <data name="Button_Update" xml:space="preserve">
     <value>Perbarui</value>
   </data>
+  <data name="ChartAnalyzer_Description" xml:space="preserve">
+    <value>Prediksi perkiraan tingkat dan analisis rincian Note sebuah chart</value>
+  </data>
+  <data name="ChartAnalyzer_Title" xml:space="preserve">
+    <value>Chart Analyzer</value>
+  </data>
+  <data name="ChartSubmit_Description" xml:space="preserve">
+    <value>Unggah dan publikasikan chart Anda</value>
+  </data>
+  <data name="ChartSubmit_Title" xml:space="preserve">
+    <value>Kirim Chart</value>
+  </data>
+  <data name="CharterToolkit_Offline_Description" xml:space="preserve">
+    <value>Edit metadata manifest chart secara lokal</value>
+  </data>
+  <data name="CharterToolkit_Offline_Title" xml:space="preserve">
+    <value>Alat Offline</value>
+  </data>
+  <data name="CharterToolkit_Online_Description" xml:space="preserve">
+    <value>Analisis dan kirim chart di situs Euterpe (terbuka di browser Anda)</value>
+  </data>
+  <data name="CharterToolkit_Online_Title" xml:space="preserve">
+    <value>Alat Online</value>
+  </data>
   <data name="ChartDifficulty_Easy" xml:space="preserve">
     <value>Mudah</value>
   </data>
@@ -187,44 +211,47 @@
   <data name="EpkEditor_Back" xml:space="preserve">
     <value>Kembali</value>
   </data>
-  <data name="EpkEditor_Bpm_Range" xml:space="preserve">
-    <value>Rentang</value>
+  <data name="EpkEditor_Charters_Watermark" xml:space="preserve">
+    <value>Tambah charter</value>
   </data>
   <data name="EpkEditor_Field_Author" xml:space="preserve">
-    <value>Penulis</value>
+    <value>Penulis Lagu</value>
   </data>
   <data name="EpkEditor_Field_BackgroundVideoOpacity" xml:space="preserve">
-    <value>Opasitas Video Latar</value>
+    <value>Opasitas Video</value>
   </data>
   <data name="EpkEditor_Field_Bpm" xml:space="preserve">
     <value>BPM</value>
   </data>
+  <data name="EpkEditor_Field_BpmMax" xml:space="preserve">
+    <value>BPM Maks</value>
+  </data>
+  <data name="EpkEditor_Field_BpmMin" xml:space="preserve">
+    <value>BPM Min</value>
+  </data>
   <data name="EpkEditor_Field_Description" xml:space="preserve">
     <value>Deskripsi</value>
-  </data>
-  <data name="EpkEditor_Field_Difficulties" xml:space="preserve">
-    <value>Kesulitan</value>
   </data>
   <data name="EpkEditor_Field_Files" xml:space="preserve">
     <value>File</value>
   </data>
   <data name="EpkEditor_Field_HideMessage" xml:space="preserve">
-    <value>Sembunyikan Pesan</value>
+    <value>Pesan</value>
   </data>
   <data name="EpkEditor_Field_HideMode" xml:space="preserve">
-    <value>Sembunyikan Mode</value>
+    <value>Mode</value>
   </data>
   <data name="EpkEditor_Field_HideRatingOverride" xml:space="preserve">
-    <value>Sembunyikan Penggantian Rating</value>
+    <value>Penggantian Tampilan Tingkat</value>
   </data>
   <data name="EpkEditor_Field_Name" xml:space="preserve">
-    <value>Nama</value>
+    <value>Nama Chart</value>
   </data>
   <data name="EpkEditor_Field_NameRomanized" xml:space="preserve">
     <value>Nama Romanisasi</value>
   </data>
   <data name="EpkEditor_Field_SafeForStreamer" xml:space="preserve">
-    <value>Aman untuk Streamer</value>
+    <value>Aman untuk streamer</value>
   </data>
   <data name="EpkEditor_Field_Scene" xml:space="preserve">
     <value>Adegan</value>
@@ -235,29 +262,62 @@
   <data name="EpkEditor_Field_SearchKeywords" xml:space="preserve">
     <value>Kata Kunci Pencarian</value>
   </data>
-  <data name="EpkEditor_Field_SearchKeywords_Description" xml:space="preserve">
-    <value>Pisahkan kata kunci dengan koma</value>
+  <data name="EpkEditor_Field_TempoVariable" xml:space="preserve">
+    <value>Tempo bervariasi</value>
   </data>
   <data name="EpkEditor_Files_Refresh" xml:space="preserve">
     <value>Segarkan</value>
   </data>
+  <data name="EpkEditor_Files_Summary" xml:space="preserve">
+    <value>{0} file · {1}</value>
+  </data>
+  <data name="EpkEditor_Hint_Required" xml:space="preserve">
+    <value>Isi semua kolom wajib untuk menyimpan</value>
+  </data>
+  <data name="EpkEditor_Hint_TempoRange" xml:space="preserve">
+    <value>Tetapkan rentang tempo yang valid (min ≤ maks)</value>
+  </data>
+  <data name="EpkEditor_Keywords_Watermark" xml:space="preserve">
+    <value>Tambah kata kunci</value>
+  </data>
   <data name="EpkEditor_Launcher_Description" xml:space="preserve">
     <value>Buka dan edit metadata manifest.epk sebuah chart</value>
-  </data>
-  <data name="EpkEditor_Launcher_Title" xml:space="preserve">
-    <value>Editor Metadata EPK</value>
-  </data>
-  <data name="EpkEditor_Map_Charters" xml:space="preserve">
-    <value>Charter</value>
   </data>
   <data name="EpkEditor_Map_Rating" xml:space="preserve">
     <value>Tingkat</value>
   </data>
+  <data name="EpkEditor_MissingFiles" xml:space="preserve">
+    <value>{0} file yang dirujuk oleh chart ini tidak ada di foldernya</value>
+  </data>
+  <data name="EpkEditor_NewFile" xml:space="preserve">
+    <value>EPK Baru…</value>
+  </data>
+  <data name="EpkEditor_New_Description" xml:space="preserve">
+    <value>Buat chart baru dari folder berisi aset</value>
+  </data>
   <data name="EpkEditor_OpenFile" xml:space="preserve">
     <value>Buka File EPK…</value>
   </data>
+  <data name="EpkEditor_OpenFolder" xml:space="preserve">
+    <value>Buka folder</value>
+  </data>
   <data name="EpkEditor_Save" xml:space="preserve">
     <value>Simpan</value>
+  </data>
+  <data name="EpkEditor_Section_ChartInfo" xml:space="preserve">
+    <value>Info Chart</value>
+  </data>
+  <data name="EpkEditor_Section_Discovery" xml:space="preserve">
+    <value>Deskripsi &amp; Penemuan</value>
+  </data>
+  <data name="EpkEditor_Section_HiddenMode" xml:space="preserve">
+    <value>Kesulitan Tersembunyi</value>
+  </data>
+  <data name="EpkEditor_Section_Identity" xml:space="preserve">
+    <value>Info Dasar</value>
+  </data>
+  <data name="EpkEditor_Section_Maps" xml:space="preserve">
+    <value>Map</value>
   </data>
   <data name="Folder_AppLogs" xml:space="preserve">
     <value>Log Aplikasi</value>

--- a/src/Euterpe.Localization/XAML/XAML.ja.resx
+++ b/src/Euterpe.Localization/XAML/XAML.ja.resx
@@ -61,6 +61,30 @@
   <data name="Button_Update" xml:space="preserve">
     <value>アップデート</value>
   </data>
+  <data name="ChartAnalyzer_Description" xml:space="preserve">
+    <value>おおよそのレベルを予測し、譜面の Note 内訳を分析</value>
+  </data>
+  <data name="ChartAnalyzer_Title" xml:space="preserve">
+    <value>譜面分析器</value>
+  </data>
+  <data name="ChartSubmit_Description" xml:space="preserve">
+    <value>譜面をアップロードして公開</value>
+  </data>
+  <data name="ChartSubmit_Title" xml:space="preserve">
+    <value>譜面を提出</value>
+  </data>
+  <data name="CharterToolkit_Offline_Description" xml:space="preserve">
+    <value>譜面の manifest メタデータをローカルで編集</value>
+  </data>
+  <data name="CharterToolkit_Offline_Title" xml:space="preserve">
+    <value>オフラインツール</value>
+  </data>
+  <data name="CharterToolkit_Online_Description" xml:space="preserve">
+    <value>Euterpe サイトで譜面を分析・提出（ブラウザで開く）</value>
+  </data>
+  <data name="CharterToolkit_Online_Title" xml:space="preserve">
+    <value>オンラインツール</value>
+  </data>
   <data name="ChartDifficulty_Easy" xml:space="preserve">
     <value>普通</value>
   </data>
@@ -187,38 +211,41 @@
   <data name="EpkEditor_Back" xml:space="preserve">
     <value>戻る</value>
   </data>
-  <data name="EpkEditor_Bpm_Range" xml:space="preserve">
-    <value>範囲</value>
+  <data name="EpkEditor_Charters_Watermark" xml:space="preserve">
+    <value>譜面作者を追加</value>
   </data>
   <data name="EpkEditor_Field_Author" xml:space="preserve">
-    <value>作者</value>
+    <value>曲作者</value>
   </data>
   <data name="EpkEditor_Field_BackgroundVideoOpacity" xml:space="preserve">
-    <value>背景動画の不透明度</value>
+    <value>動画の不透明度</value>
   </data>
   <data name="EpkEditor_Field_Bpm" xml:space="preserve">
     <value>BPM</value>
   </data>
+  <data name="EpkEditor_Field_BpmMax" xml:space="preserve">
+    <value>最大 BPM</value>
+  </data>
+  <data name="EpkEditor_Field_BpmMin" xml:space="preserve">
+    <value>最小 BPM</value>
+  </data>
   <data name="EpkEditor_Field_Description" xml:space="preserve">
     <value>説明</value>
-  </data>
-  <data name="EpkEditor_Field_Difficulties" xml:space="preserve">
-    <value>難易度</value>
   </data>
   <data name="EpkEditor_Field_Files" xml:space="preserve">
     <value>ファイル</value>
   </data>
   <data name="EpkEditor_Field_HideMessage" xml:space="preserve">
-    <value>非表示メッセージ</value>
+    <value>メッセージ</value>
   </data>
   <data name="EpkEditor_Field_HideMode" xml:space="preserve">
-    <value>非表示モード</value>
+    <value>モード</value>
   </data>
   <data name="EpkEditor_Field_HideRatingOverride" xml:space="preserve">
-    <value>レベル上書きを非表示</value>
+    <value>レベル表示の上書き</value>
   </data>
   <data name="EpkEditor_Field_Name" xml:space="preserve">
-    <value>名前</value>
+    <value>曲名</value>
   </data>
   <data name="EpkEditor_Field_NameRomanized" xml:space="preserve">
     <value>ローマ字名</value>
@@ -235,29 +262,62 @@
   <data name="EpkEditor_Field_SearchKeywords" xml:space="preserve">
     <value>検索キーワード</value>
   </data>
-  <data name="EpkEditor_Field_SearchKeywords_Description" xml:space="preserve">
-    <value>キーワードをカンマで区切る</value>
+  <data name="EpkEditor_Field_TempoVariable" xml:space="preserve">
+    <value>変速</value>
   </data>
   <data name="EpkEditor_Files_Refresh" xml:space="preserve">
     <value>更新</value>
   </data>
+  <data name="EpkEditor_Files_Summary" xml:space="preserve">
+    <value>{0} 個のファイル · {1}</value>
+  </data>
+  <data name="EpkEditor_Hint_Required" xml:space="preserve">
+    <value>すべての必須項目を入力すると保存できます</value>
+  </data>
+  <data name="EpkEditor_Hint_TempoRange" xml:space="preserve">
+    <value>有効なテンポ範囲を設定してください（最小 ≤ 最大）</value>
+  </data>
+  <data name="EpkEditor_Keywords_Watermark" xml:space="preserve">
+    <value>キーワードを追加</value>
+  </data>
   <data name="EpkEditor_Launcher_Description" xml:space="preserve">
     <value>譜面の manifest.epk のメタデータを開いて編集</value>
-  </data>
-  <data name="EpkEditor_Launcher_Title" xml:space="preserve">
-    <value>EPK メタデータエディター</value>
-  </data>
-  <data name="EpkEditor_Map_Charters" xml:space="preserve">
-    <value>譜面作者</value>
   </data>
   <data name="EpkEditor_Map_Rating" xml:space="preserve">
     <value>レベル</value>
   </data>
+  <data name="EpkEditor_MissingFiles" xml:space="preserve">
+    <value>この譜面が参照している {0} 個のファイルがフォルダ内に見つかりません</value>
+  </data>
+  <data name="EpkEditor_NewFile" xml:space="preserve">
+    <value>新規 EPK…</value>
+  </data>
+  <data name="EpkEditor_New_Description" xml:space="preserve">
+    <value>素材を入れたフォルダから新しい譜面を作成</value>
+  </data>
   <data name="EpkEditor_OpenFile" xml:space="preserve">
     <value>EPK ファイルを開く…</value>
   </data>
+  <data name="EpkEditor_OpenFolder" xml:space="preserve">
+    <value>フォルダを開く</value>
+  </data>
   <data name="EpkEditor_Save" xml:space="preserve">
     <value>保存</value>
+  </data>
+  <data name="EpkEditor_Section_ChartInfo" xml:space="preserve">
+    <value>譜面情報</value>
+  </data>
+  <data name="EpkEditor_Section_Discovery" xml:space="preserve">
+    <value>説明と発見</value>
+  </data>
+  <data name="EpkEditor_Section_HiddenMode" xml:space="preserve">
+    <value>隠し難易度</value>
+  </data>
+  <data name="EpkEditor_Section_Identity" xml:space="preserve">
+    <value>基本情報</value>
+  </data>
+  <data name="EpkEditor_Section_Maps" xml:space="preserve">
+    <value>マップ</value>
   </data>
   <data name="Folder_AppLogs" xml:space="preserve">
     <value>アプリログ</value>

--- a/src/Euterpe.Localization/XAML/XAML.ko.resx
+++ b/src/Euterpe.Localization/XAML/XAML.ko.resx
@@ -61,6 +61,30 @@
   <data name="Button_Update" xml:space="preserve">
     <value>업데이트</value>
   </data>
+  <data name="ChartAnalyzer_Description" xml:space="preserve">
+    <value>대략적인 레벨을 예측하고 채보의 Note 분석</value>
+  </data>
+  <data name="ChartAnalyzer_Title" xml:space="preserve">
+    <value>채보 분석기</value>
+  </data>
+  <data name="ChartSubmit_Description" xml:space="preserve">
+    <value>채보를 업로드하고 게시</value>
+  </data>
+  <data name="ChartSubmit_Title" xml:space="preserve">
+    <value>채보 제출</value>
+  </data>
+  <data name="CharterToolkit_Offline_Description" xml:space="preserve">
+    <value>채보의 manifest 메타데이터를 로컬에서 편집</value>
+  </data>
+  <data name="CharterToolkit_Offline_Title" xml:space="preserve">
+    <value>오프라인 도구</value>
+  </data>
+  <data name="CharterToolkit_Online_Description" xml:space="preserve">
+    <value>Euterpe 사이트에서 채보를 분석하고 제출 (브라우저에서 열림)</value>
+  </data>
+  <data name="CharterToolkit_Online_Title" xml:space="preserve">
+    <value>온라인 도구</value>
+  </data>
   <data name="ChartDifficulty_Easy" xml:space="preserve">
     <value>쉬움</value>
   </data>
@@ -187,38 +211,41 @@
   <data name="EpkEditor_Back" xml:space="preserve">
     <value>뒤로</value>
   </data>
-  <data name="EpkEditor_Bpm_Range" xml:space="preserve">
-    <value>범위</value>
+  <data name="EpkEditor_Charters_Watermark" xml:space="preserve">
+    <value>채보 제작자 추가</value>
   </data>
   <data name="EpkEditor_Field_Author" xml:space="preserve">
-    <value>작성자</value>
+    <value>작곡가</value>
   </data>
   <data name="EpkEditor_Field_BackgroundVideoOpacity" xml:space="preserve">
-    <value>배경 영상 불투명도</value>
+    <value>영상 불투명도</value>
   </data>
   <data name="EpkEditor_Field_Bpm" xml:space="preserve">
     <value>BPM</value>
   </data>
+  <data name="EpkEditor_Field_BpmMax" xml:space="preserve">
+    <value>최대 BPM</value>
+  </data>
+  <data name="EpkEditor_Field_BpmMin" xml:space="preserve">
+    <value>최소 BPM</value>
+  </data>
   <data name="EpkEditor_Field_Description" xml:space="preserve">
     <value>설명</value>
-  </data>
-  <data name="EpkEditor_Field_Difficulties" xml:space="preserve">
-    <value>난이도</value>
   </data>
   <data name="EpkEditor_Field_Files" xml:space="preserve">
     <value>파일</value>
   </data>
   <data name="EpkEditor_Field_HideMessage" xml:space="preserve">
-    <value>숨김 메시지</value>
+    <value>메시지</value>
   </data>
   <data name="EpkEditor_Field_HideMode" xml:space="preserve">
-    <value>숨김 모드</value>
+    <value>모드</value>
   </data>
   <data name="EpkEditor_Field_HideRatingOverride" xml:space="preserve">
-    <value>난이도 재정의 숨김</value>
+    <value>레벨 표시 재정의</value>
   </data>
   <data name="EpkEditor_Field_Name" xml:space="preserve">
-    <value>이름</value>
+    <value>곡명</value>
   </data>
   <data name="EpkEditor_Field_NameRomanized" xml:space="preserve">
     <value>로마자 이름</value>
@@ -235,29 +262,62 @@
   <data name="EpkEditor_Field_SearchKeywords" xml:space="preserve">
     <value>검색 키워드</value>
   </data>
-  <data name="EpkEditor_Field_SearchKeywords_Description" xml:space="preserve">
-    <value>쉼표로 키워드를 구분하세요</value>
+  <data name="EpkEditor_Field_TempoVariable" xml:space="preserve">
+    <value>변속</value>
   </data>
   <data name="EpkEditor_Files_Refresh" xml:space="preserve">
     <value>새로 고침</value>
   </data>
+  <data name="EpkEditor_Files_Summary" xml:space="preserve">
+    <value>파일 {0}개 · {1}</value>
+  </data>
+  <data name="EpkEditor_Hint_Required" xml:space="preserve">
+    <value>모든 필수 항목을 입력하면 저장할 수 있습니다</value>
+  </data>
+  <data name="EpkEditor_Hint_TempoRange" xml:space="preserve">
+    <value>유효한 템포 범위를 설정하세요 (최소 ≤ 최대)</value>
+  </data>
+  <data name="EpkEditor_Keywords_Watermark" xml:space="preserve">
+    <value>키워드 추가</value>
+  </data>
   <data name="EpkEditor_Launcher_Description" xml:space="preserve">
     <value>채보의 manifest.epk 메타데이터를 열고 편집합니다</value>
-  </data>
-  <data name="EpkEditor_Launcher_Title" xml:space="preserve">
-    <value>EPK 메타데이터 편집기</value>
-  </data>
-  <data name="EpkEditor_Map_Charters" xml:space="preserve">
-    <value>채보 제작자</value>
   </data>
   <data name="EpkEditor_Map_Rating" xml:space="preserve">
     <value>레벨</value>
   </data>
+  <data name="EpkEditor_MissingFiles" xml:space="preserve">
+    <value>이 채보가 참조하는 파일 {0}개가 폴더에 없습니다</value>
+  </data>
+  <data name="EpkEditor_NewFile" xml:space="preserve">
+    <value>새 EPK…</value>
+  </data>
+  <data name="EpkEditor_New_Description" xml:space="preserve">
+    <value>소재를 모아 둔 폴더에서 새 채보를 만듭니다</value>
+  </data>
   <data name="EpkEditor_OpenFile" xml:space="preserve">
     <value>EPK 파일 열기…</value>
   </data>
+  <data name="EpkEditor_OpenFolder" xml:space="preserve">
+    <value>폴더 열기</value>
+  </data>
   <data name="EpkEditor_Save" xml:space="preserve">
     <value>저장</value>
+  </data>
+  <data name="EpkEditor_Section_ChartInfo" xml:space="preserve">
+    <value>채보 정보</value>
+  </data>
+  <data name="EpkEditor_Section_Discovery" xml:space="preserve">
+    <value>설명 및 탐색</value>
+  </data>
+  <data name="EpkEditor_Section_HiddenMode" xml:space="preserve">
+    <value>히든 난이도</value>
+  </data>
+  <data name="EpkEditor_Section_Identity" xml:space="preserve">
+    <value>기본 정보</value>
+  </data>
+  <data name="EpkEditor_Section_Maps" xml:space="preserve">
+    <value>맵</value>
   </data>
   <data name="Folder_AppLogs" xml:space="preserve">
     <value>앱 로그</value>

--- a/src/Euterpe.Localization/XAML/XAML.nl.resx
+++ b/src/Euterpe.Localization/XAML/XAML.nl.resx
@@ -61,6 +61,30 @@
   <data name="Button_Update" xml:space="preserve">
     <value>Bijwerken</value>
   </data>
+  <data name="ChartAnalyzer_Description" xml:space="preserve">
+    <value>Voorspel bij benadering de niveaus en analyseer de Note-opbouw van een chart</value>
+  </data>
+  <data name="ChartAnalyzer_Title" xml:space="preserve">
+    <value>Chart Analyzer</value>
+  </data>
+  <data name="ChartSubmit_Description" xml:space="preserve">
+    <value>Upload en publiceer je chart</value>
+  </data>
+  <data name="ChartSubmit_Title" xml:space="preserve">
+    <value>Chart indienen</value>
+  </data>
+  <data name="CharterToolkit_Offline_Description" xml:space="preserve">
+    <value>Bewerk de manifest-metadata van een chart lokaal</value>
+  </data>
+  <data name="CharterToolkit_Offline_Title" xml:space="preserve">
+    <value>Offline-tools</value>
+  </data>
+  <data name="CharterToolkit_Online_Description" xml:space="preserve">
+    <value>Analyseer en dien charts in op de Euterpe-site (opent in je browser)</value>
+  </data>
+  <data name="CharterToolkit_Online_Title" xml:space="preserve">
+    <value>Online-tools</value>
+  </data>
   <data name="ChartDifficulty_Easy" xml:space="preserve">
     <value>Makkelijk</value>
   </data>
@@ -187,38 +211,41 @@
   <data name="EpkEditor_Back" xml:space="preserve">
     <value>Terug</value>
   </data>
-  <data name="EpkEditor_Bpm_Range" xml:space="preserve">
-    <value>Bereik</value>
+  <data name="EpkEditor_Charters_Watermark" xml:space="preserve">
+    <value>Een charter toevoegen</value>
   </data>
   <data name="EpkEditor_Field_Author" xml:space="preserve">
-    <value>Auteur</value>
+    <value>Songauteur</value>
   </data>
   <data name="EpkEditor_Field_BackgroundVideoOpacity" xml:space="preserve">
-    <value>Achtergrondvideo-transparantie</value>
+    <value>Videotransparantie</value>
   </data>
   <data name="EpkEditor_Field_Bpm" xml:space="preserve">
     <value>BPM</value>
   </data>
+  <data name="EpkEditor_Field_BpmMax" xml:space="preserve">
+    <value>Max. BPM</value>
+  </data>
+  <data name="EpkEditor_Field_BpmMin" xml:space="preserve">
+    <value>Min. BPM</value>
+  </data>
   <data name="EpkEditor_Field_Description" xml:space="preserve">
     <value>Beschrijving</value>
-  </data>
-  <data name="EpkEditor_Field_Difficulties" xml:space="preserve">
-    <value>Moeilijkheidsgraden</value>
   </data>
   <data name="EpkEditor_Field_Files" xml:space="preserve">
     <value>Bestanden</value>
   </data>
   <data name="EpkEditor_Field_HideMessage" xml:space="preserve">
-    <value>Verborgen bericht</value>
+    <value>Bericht</value>
   </data>
   <data name="EpkEditor_Field_HideMode" xml:space="preserve">
-    <value>Verborgen modus</value>
+    <value>Modus</value>
   </data>
   <data name="EpkEditor_Field_HideRatingOverride" xml:space="preserve">
-    <value>Niveauoverschrijving verbergen</value>
+    <value>Niveauweergave overschrijven</value>
   </data>
   <data name="EpkEditor_Field_Name" xml:space="preserve">
-    <value>Naam</value>
+    <value>Chartnaam</value>
   </data>
   <data name="EpkEditor_Field_NameRomanized" xml:space="preserve">
     <value>Geromaniseerde naam</value>
@@ -235,29 +262,62 @@
   <data name="EpkEditor_Field_SearchKeywords" xml:space="preserve">
     <value>Zoekwoorden</value>
   </data>
-  <data name="EpkEditor_Field_SearchKeywords_Description" xml:space="preserve">
-    <value>Zoekwoorden scheiden met komma's</value>
+  <data name="EpkEditor_Field_TempoVariable" xml:space="preserve">
+    <value>Variabel tempo</value>
   </data>
   <data name="EpkEditor_Files_Refresh" xml:space="preserve">
     <value>Vernieuwen</value>
   </data>
+  <data name="EpkEditor_Files_Summary" xml:space="preserve">
+    <value>{0} bestanden · {1}</value>
+  </data>
+  <data name="EpkEditor_Hint_Required" xml:space="preserve">
+    <value>Vul alle verplichte velden in om op te slaan</value>
+  </data>
+  <data name="EpkEditor_Hint_TempoRange" xml:space="preserve">
+    <value>Stel een geldig tempobereik in (min ≤ max)</value>
+  </data>
+  <data name="EpkEditor_Keywords_Watermark" xml:space="preserve">
+    <value>Een zoekwoord toevoegen</value>
+  </data>
   <data name="EpkEditor_Launcher_Description" xml:space="preserve">
-    <value>De metadata van het manifest.epk van een chart openen en bewerken</value>
-  </data>
-  <data name="EpkEditor_Launcher_Title" xml:space="preserve">
-    <value>EPK-metadata-editor</value>
-  </data>
-  <data name="EpkEditor_Map_Charters" xml:space="preserve">
-    <value>Charters</value>
+    <value>De manifest.epk van een chart openen en de metadata ervan bewerken</value>
   </data>
   <data name="EpkEditor_Map_Rating" xml:space="preserve">
     <value>Niveau</value>
   </data>
+  <data name="EpkEditor_MissingFiles" xml:space="preserve">
+    <value>{0} bestand(en) waarnaar deze chart verwijst ontbreken in de map</value>
+  </data>
+  <data name="EpkEditor_NewFile" xml:space="preserve">
+    <value>Nieuwe EPK…</value>
+  </data>
+  <data name="EpkEditor_New_Description" xml:space="preserve">
+    <value>Een nieuwe chart bouwen vanuit een map met assets</value>
+  </data>
   <data name="EpkEditor_OpenFile" xml:space="preserve">
     <value>EPK-bestand openen…</value>
   </data>
+  <data name="EpkEditor_OpenFolder" xml:space="preserve">
+    <value>Map openen</value>
+  </data>
   <data name="EpkEditor_Save" xml:space="preserve">
     <value>Opslaan</value>
+  </data>
+  <data name="EpkEditor_Section_ChartInfo" xml:space="preserve">
+    <value>Chart-info</value>
+  </data>
+  <data name="EpkEditor_Section_Discovery" xml:space="preserve">
+    <value>Beschrijving &amp; vindbaarheid</value>
+  </data>
+  <data name="EpkEditor_Section_HiddenMode" xml:space="preserve">
+    <value>Verborgen moeilijkheid</value>
+  </data>
+  <data name="EpkEditor_Section_Identity" xml:space="preserve">
+    <value>Basisinfo</value>
+  </data>
+  <data name="EpkEditor_Section_Maps" xml:space="preserve">
+    <value>Maps</value>
   </data>
   <data name="Folder_AppLogs" xml:space="preserve">
     <value>App-logs</value>

--- a/src/Euterpe.Localization/XAML/XAML.pt.resx
+++ b/src/Euterpe.Localization/XAML/XAML.pt.resx
@@ -61,6 +61,30 @@
   <data name="Button_Update" xml:space="preserve">
     <value>Atualizar</value>
   </data>
+  <data name="ChartAnalyzer_Description" xml:space="preserve">
+    <value>Prevê classificações aproximadas e analisa a distribuição de Note de um chart</value>
+  </data>
+  <data name="ChartAnalyzer_Title" xml:space="preserve">
+    <value>Chart Analyzer</value>
+  </data>
+  <data name="ChartSubmit_Description" xml:space="preserve">
+    <value>Envie e publique seu chart</value>
+  </data>
+  <data name="ChartSubmit_Title" xml:space="preserve">
+    <value>Enviar chart</value>
+  </data>
+  <data name="CharterToolkit_Offline_Description" xml:space="preserve">
+    <value>Edite localmente os metadados do manifest de um chart</value>
+  </data>
+  <data name="CharterToolkit_Offline_Title" xml:space="preserve">
+    <value>Ferramentas offline</value>
+  </data>
+  <data name="CharterToolkit_Online_Description" xml:space="preserve">
+    <value>Analise e envie charts no site do Euterpe (abre no seu navegador)</value>
+  </data>
+  <data name="CharterToolkit_Online_Title" xml:space="preserve">
+    <value>Ferramentas online</value>
+  </data>
   <data name="ChartDifficulty_Easy" xml:space="preserve">
     <value>Fácil</value>
   </data>
@@ -187,44 +211,47 @@
   <data name="EpkEditor_Back" xml:space="preserve">
     <value>Voltar</value>
   </data>
-  <data name="EpkEditor_Bpm_Range" xml:space="preserve">
-    <value>Intervalo</value>
+  <data name="EpkEditor_Charters_Watermark" xml:space="preserve">
+    <value>Adicionar um charter</value>
   </data>
   <data name="EpkEditor_Field_Author" xml:space="preserve">
-    <value>Autor</value>
+    <value>Autor da música</value>
   </data>
   <data name="EpkEditor_Field_BackgroundVideoOpacity" xml:space="preserve">
-    <value>Opacidade do vídeo de fundo</value>
+    <value>Opacidade do vídeo</value>
   </data>
   <data name="EpkEditor_Field_Bpm" xml:space="preserve">
     <value>BPM</value>
   </data>
+  <data name="EpkEditor_Field_BpmMax" xml:space="preserve">
+    <value>BPM máx.</value>
+  </data>
+  <data name="EpkEditor_Field_BpmMin" xml:space="preserve">
+    <value>BPM mín.</value>
+  </data>
   <data name="EpkEditor_Field_Description" xml:space="preserve">
     <value>Descrição</value>
-  </data>
-  <data name="EpkEditor_Field_Difficulties" xml:space="preserve">
-    <value>Dificuldades</value>
   </data>
   <data name="EpkEditor_Field_Files" xml:space="preserve">
     <value>Arquivos</value>
   </data>
   <data name="EpkEditor_Field_HideMessage" xml:space="preserve">
-    <value>Mensagem de ocultação</value>
+    <value>Mensagem</value>
   </data>
   <data name="EpkEditor_Field_HideMode" xml:space="preserve">
-    <value>Modo oculto</value>
+    <value>Modo</value>
   </data>
   <data name="EpkEditor_Field_HideRatingOverride" xml:space="preserve">
-    <value>Ocultar substituição de nível</value>
+    <value>Substituição de nível exibido</value>
   </data>
   <data name="EpkEditor_Field_Name" xml:space="preserve">
-    <value>Nome</value>
+    <value>Nome do chart</value>
   </data>
   <data name="EpkEditor_Field_NameRomanized" xml:space="preserve">
     <value>Nome romanizado</value>
   </data>
   <data name="EpkEditor_Field_SafeForStreamer" xml:space="preserve">
-    <value>Seguro para streamer</value>
+    <value>Seguro para streamers</value>
   </data>
   <data name="EpkEditor_Field_Scene" xml:space="preserve">
     <value>Cena</value>
@@ -235,29 +262,62 @@
   <data name="EpkEditor_Field_SearchKeywords" xml:space="preserve">
     <value>Palavras-chave de pesquisa</value>
   </data>
-  <data name="EpkEditor_Field_SearchKeywords_Description" xml:space="preserve">
-    <value>Separe as palavras-chave com vírgulas</value>
+  <data name="EpkEditor_Field_TempoVariable" xml:space="preserve">
+    <value>Tempo variável</value>
   </data>
   <data name="EpkEditor_Files_Refresh" xml:space="preserve">
     <value>Atualizar</value>
   </data>
+  <data name="EpkEditor_Files_Summary" xml:space="preserve">
+    <value>{0} arquivos · {1}</value>
+  </data>
+  <data name="EpkEditor_Hint_Required" xml:space="preserve">
+    <value>Preencha todos os campos obrigatórios para salvar</value>
+  </data>
+  <data name="EpkEditor_Hint_TempoRange" xml:space="preserve">
+    <value>Defina um intervalo de tempo válido (mín ≤ máx)</value>
+  </data>
+  <data name="EpkEditor_Keywords_Watermark" xml:space="preserve">
+    <value>Adicionar uma palavra-chave</value>
+  </data>
   <data name="EpkEditor_Launcher_Description" xml:space="preserve">
     <value>Abrir e editar os metadados do manifest.epk de um chart</value>
-  </data>
-  <data name="EpkEditor_Launcher_Title" xml:space="preserve">
-    <value>Editor de metadados EPK</value>
-  </data>
-  <data name="EpkEditor_Map_Charters" xml:space="preserve">
-    <value>Charters</value>
   </data>
   <data name="EpkEditor_Map_Rating" xml:space="preserve">
     <value>Nível</value>
   </data>
+  <data name="EpkEditor_MissingFiles" xml:space="preserve">
+    <value>{0} arquivo(s) referenciado(s) por este chart estão ausentes da pasta dele</value>
+  </data>
+  <data name="EpkEditor_NewFile" xml:space="preserve">
+    <value>Novo EPK…</value>
+  </data>
+  <data name="EpkEditor_New_Description" xml:space="preserve">
+    <value>Crie um chart a partir de uma pasta de recursos</value>
+  </data>
   <data name="EpkEditor_OpenFile" xml:space="preserve">
     <value>Abrir arquivo EPK…</value>
   </data>
+  <data name="EpkEditor_OpenFolder" xml:space="preserve">
+    <value>Abrir pasta</value>
+  </data>
   <data name="EpkEditor_Save" xml:space="preserve">
     <value>Salvar</value>
+  </data>
+  <data name="EpkEditor_Section_ChartInfo" xml:space="preserve">
+    <value>Informações do chart</value>
+  </data>
+  <data name="EpkEditor_Section_Discovery" xml:space="preserve">
+    <value>Descrição e descoberta</value>
+  </data>
+  <data name="EpkEditor_Section_HiddenMode" xml:space="preserve">
+    <value>Dificuldade oculta</value>
+  </data>
+  <data name="EpkEditor_Section_Identity" xml:space="preserve">
+    <value>Informações básicas</value>
+  </data>
+  <data name="EpkEditor_Section_Maps" xml:space="preserve">
+    <value>Mapas</value>
   </data>
   <data name="Folder_AppLogs" xml:space="preserve">
     <value>Logs do aplicativo</value>

--- a/src/Euterpe.Localization/XAML/XAML.resx
+++ b/src/Euterpe.Localization/XAML/XAML.resx
@@ -61,6 +61,30 @@
   <data name="Button_Update" xml:space="preserve">
     <value>Update</value>
   </data>
+  <data name="ChartAnalyzer_Description" xml:space="preserve">
+    <value>Predict approximate ratings and analyse a chart's Note breakdown</value>
+  </data>
+  <data name="ChartAnalyzer_Title" xml:space="preserve">
+    <value>Chart Analyzer</value>
+  </data>
+  <data name="ChartSubmit_Description" xml:space="preserve">
+    <value>Upload and publish your chart</value>
+  </data>
+  <data name="ChartSubmit_Title" xml:space="preserve">
+    <value>Submit Chart</value>
+  </data>
+  <data name="CharterToolkit_Offline_Description" xml:space="preserve">
+    <value>Edit a chart's manifest metadata locally</value>
+  </data>
+  <data name="CharterToolkit_Offline_Title" xml:space="preserve">
+    <value>Offline Tools</value>
+  </data>
+  <data name="CharterToolkit_Online_Description" xml:space="preserve">
+    <value>Analyse and submit charts on the Euterpe site (opens in your browser)</value>
+  </data>
+  <data name="CharterToolkit_Online_Title" xml:space="preserve">
+    <value>Online Tools</value>
+  </data>
   <data name="ChartDifficulty_Easy" xml:space="preserve">
     <value>Easy</value>
   </data>
@@ -197,46 +221,49 @@
     <value>Add a charter</value>
   </data>
   <data name="EpkEditor_Field_Author" xml:space="preserve">
-    <value>Author</value>
+    <value>Song Author</value>
   </data>
   <data name="EpkEditor_Field_BackgroundVideoOpacity" xml:space="preserve">
-    <value>Background Video Opacity</value>
+    <value>Video Opacity</value>
   </data>
   <data name="EpkEditor_Field_Bpm" xml:space="preserve">
     <value>BPM</value>
   </data>
+  <data name="EpkEditor_Field_BpmMax" xml:space="preserve">
+    <value>Max BPM</value>
+  </data>
+  <data name="EpkEditor_Field_BpmMin" xml:space="preserve">
+    <value>Min BPM</value>
+  </data>
   <data name="EpkEditor_Field_Description" xml:space="preserve">
     <value>Description</value>
-  </data>
-  <data name="EpkEditor_Field_Difficulties" xml:space="preserve">
-    <value>Difficulties</value>
   </data>
   <data name="EpkEditor_Field_Files" xml:space="preserve">
     <value>Files</value>
   </data>
   <data name="EpkEditor_Field_HideMessage" xml:space="preserve">
-    <value>Hide Message</value>
+    <value>Message</value>
   </data>
   <data name="EpkEditor_Field_HideMode" xml:space="preserve">
-    <value>Hide Mode</value>
+    <value>Mode</value>
   </data>
   <data name="EpkEditor_Field_HideRatingOverride" xml:space="preserve">
-    <value>Hide Rating Override</value>
+    <value>Rating Display Override</value>
   </data>
   <data name="EpkEditor_Field_Name" xml:space="preserve">
-    <value>Name</value>
+    <value>Chart Name</value>
   </data>
   <data name="EpkEditor_Field_NameRomanized" xml:space="preserve">
     <value>Romanized Name</value>
   </data>
   <data name="EpkEditor_Field_SafeForStreamer" xml:space="preserve">
-    <value>Safe for Streamer</value>
+    <value>Safe for streamers</value>
   </data>
   <data name="EpkEditor_Field_Scene" xml:space="preserve">
     <value>Scene</value>
   </data>
   <data name="EpkEditor_Field_SceneEgg" xml:space="preserve">
-    <value>Scene (Easter Egg)</value>
+    <value>Scene Egg</value>
   </data>
   <data name="EpkEditor_Field_SearchKeywords" xml:space="preserve">
     <value>Search Keywords</value>
@@ -250,8 +277,8 @@
   <data name="EpkEditor_Files_Summary" xml:space="preserve">
     <value>{0} files · {1}</value>
   </data>
-  <data name="EpkEditor_Hint_NameAuthorRequired" xml:space="preserve">
-    <value>Enter a song name and author to save</value>
+  <data name="EpkEditor_Hint_Required" xml:space="preserve">
+    <value>Fill in all required fields to save</value>
   </data>
   <data name="EpkEditor_Hint_TempoRange" xml:space="preserve">
     <value>Set a valid tempo range (min ≤ max)</value>
@@ -262,17 +289,17 @@
   <data name="EpkEditor_Launcher_Description" xml:space="preserve">
     <value>Open and edit the metadata of a chart's manifest.epk</value>
   </data>
-  <data name="EpkEditor_Launcher_Title" xml:space="preserve">
-    <value>EPK Metadata Editor</value>
-  </data>
-  <data name="EpkEditor_Map_Charters" xml:space="preserve">
-    <value>Charters</value>
-  </data>
   <data name="EpkEditor_Map_Rating" xml:space="preserve">
     <value>Rating</value>
   </data>
   <data name="EpkEditor_MissingFiles" xml:space="preserve">
     <value>{0} file(s) referenced by this chart are missing from its folder</value>
+  </data>
+  <data name="EpkEditor_NewFile" xml:space="preserve">
+    <value>New EPK…</value>
+  </data>
+  <data name="EpkEditor_New_Description" xml:space="preserve">
+    <value>Build a new chart from a folder of assets</value>
   </data>
   <data name="EpkEditor_OpenFile" xml:space="preserve">
     <value>Open EPK File…</value>
@@ -283,17 +310,20 @@
   <data name="EpkEditor_Save" xml:space="preserve">
     <value>Save</value>
   </data>
-  <data name="EpkEditor_Section_Discovery" xml:space="preserve">
-    <value>Discovery</value>
+  <data name="EpkEditor_Section_ChartInfo" xml:space="preserve">
+    <value>Chart Info</value>
   </data>
-  <data name="EpkEditor_Section_Gameplay" xml:space="preserve">
-    <value>Gameplay</value>
+  <data name="EpkEditor_Section_Discovery" xml:space="preserve">
+    <value>Description &amp; Discovery</value>
   </data>
   <data name="EpkEditor_Section_HiddenMode" xml:space="preserve">
     <value>Hidden Difficulty</value>
   </data>
   <data name="EpkEditor_Section_Identity" xml:space="preserve">
-    <value>Identity</value>
+    <value>Basic Info</value>
+  </data>
+  <data name="EpkEditor_Section_Maps" xml:space="preserve">
+    <value>Maps</value>
   </data>
   <data name="Folder_AppLogs" xml:space="preserve">
     <value>App Logs</value>

--- a/src/Euterpe.Localization/XAML/XAML.ru.resx
+++ b/src/Euterpe.Localization/XAML/XAML.ru.resx
@@ -61,6 +61,30 @@
   <data name="Button_Update" xml:space="preserve">
     <value>Обновить</value>
   </data>
+  <data name="ChartAnalyzer_Description" xml:space="preserve">
+    <value>Прогнозировать приблизительные уровни и анализировать разбивку Note чарта</value>
+  </data>
+  <data name="ChartAnalyzer_Title" xml:space="preserve">
+    <value>Chart Analyzer</value>
+  </data>
+  <data name="ChartSubmit_Description" xml:space="preserve">
+    <value>Загрузите и опубликуйте свой чарт</value>
+  </data>
+  <data name="ChartSubmit_Title" xml:space="preserve">
+    <value>Отправить чарт</value>
+  </data>
+  <data name="CharterToolkit_Offline_Description" xml:space="preserve">
+    <value>Редактировать метаданные manifest чарта локально</value>
+  </data>
+  <data name="CharterToolkit_Offline_Title" xml:space="preserve">
+    <value>Офлайн-инструменты</value>
+  </data>
+  <data name="CharterToolkit_Online_Description" xml:space="preserve">
+    <value>Анализировать и отправлять чарты на сайте Euterpe (откроется в браузере)</value>
+  </data>
+  <data name="CharterToolkit_Online_Title" xml:space="preserve">
+    <value>Онлайн-инструменты</value>
+  </data>
   <data name="ChartDifficulty_Easy" xml:space="preserve">
     <value>Легко</value>
   </data>
@@ -187,38 +211,41 @@
   <data name="EpkEditor_Back" xml:space="preserve">
     <value>Назад</value>
   </data>
-  <data name="EpkEditor_Bpm_Range" xml:space="preserve">
-    <value>Диапазон</value>
+  <data name="EpkEditor_Charters_Watermark" xml:space="preserve">
+    <value>Добавить чартера</value>
   </data>
   <data name="EpkEditor_Field_Author" xml:space="preserve">
-    <value>Автор</value>
+    <value>Автор песни</value>
   </data>
   <data name="EpkEditor_Field_BackgroundVideoOpacity" xml:space="preserve">
-    <value>Прозрачность фонового видео</value>
+    <value>Прозрачность видео</value>
   </data>
   <data name="EpkEditor_Field_Bpm" xml:space="preserve">
     <value>BPM</value>
   </data>
+  <data name="EpkEditor_Field_BpmMax" xml:space="preserve">
+    <value>Макс. BPM</value>
+  </data>
+  <data name="EpkEditor_Field_BpmMin" xml:space="preserve">
+    <value>Мин. BPM</value>
+  </data>
   <data name="EpkEditor_Field_Description" xml:space="preserve">
     <value>Описание</value>
-  </data>
-  <data name="EpkEditor_Field_Difficulties" xml:space="preserve">
-    <value>Сложности</value>
   </data>
   <data name="EpkEditor_Field_Files" xml:space="preserve">
     <value>Файлы</value>
   </data>
   <data name="EpkEditor_Field_HideMessage" xml:space="preserve">
-    <value>Скрытое сообщение</value>
+    <value>Сообщение</value>
   </data>
   <data name="EpkEditor_Field_HideMode" xml:space="preserve">
-    <value>Скрытый режим</value>
+    <value>Режим</value>
   </data>
   <data name="EpkEditor_Field_HideRatingOverride" xml:space="preserve">
-    <value>Переопределение скрытого уровня</value>
+    <value>Переопределение отображения уровня</value>
   </data>
   <data name="EpkEditor_Field_Name" xml:space="preserve">
-    <value>Название</value>
+    <value>Название чарта</value>
   </data>
   <data name="EpkEditor_Field_NameRomanized" xml:space="preserve">
     <value>Название романизацией</value>
@@ -235,29 +262,62 @@
   <data name="EpkEditor_Field_SearchKeywords" xml:space="preserve">
     <value>Ключевые слова поиска</value>
   </data>
-  <data name="EpkEditor_Field_SearchKeywords_Description" xml:space="preserve">
-    <value>Разделяйте ключевые слова запятыми</value>
+  <data name="EpkEditor_Field_TempoVariable" xml:space="preserve">
+    <value>Переменный темп</value>
   </data>
   <data name="EpkEditor_Files_Refresh" xml:space="preserve">
     <value>Обновить</value>
   </data>
+  <data name="EpkEditor_Files_Summary" xml:space="preserve">
+    <value>{0} файлов · {1}</value>
+  </data>
+  <data name="EpkEditor_Hint_Required" xml:space="preserve">
+    <value>Заполните все обязательные поля для сохранения</value>
+  </data>
+  <data name="EpkEditor_Hint_TempoRange" xml:space="preserve">
+    <value>Задайте допустимый диапазон темпа (мин ≤ макс)</value>
+  </data>
+  <data name="EpkEditor_Keywords_Watermark" xml:space="preserve">
+    <value>Добавить ключевое слово</value>
+  </data>
   <data name="EpkEditor_Launcher_Description" xml:space="preserve">
-    <value>Открыть и редактировать метаданные файла manifest.epk чарта</value>
-  </data>
-  <data name="EpkEditor_Launcher_Title" xml:space="preserve">
-    <value>Редактор метаданных EPK</value>
-  </data>
-  <data name="EpkEditor_Map_Charters" xml:space="preserve">
-    <value>Чартеры</value>
+    <value>Открыть manifest.epk чарта и редактировать его метаданные</value>
   </data>
   <data name="EpkEditor_Map_Rating" xml:space="preserve">
     <value>Уровень</value>
   </data>
+  <data name="EpkEditor_MissingFiles" xml:space="preserve">
+    <value>{0} файл(ов), на которые ссылается этот чарт, отсутствуют в его папке</value>
+  </data>
+  <data name="EpkEditor_NewFile" xml:space="preserve">
+    <value>Новый EPK…</value>
+  </data>
+  <data name="EpkEditor_New_Description" xml:space="preserve">
+    <value>Создать новый чарт из папки с ресурсами</value>
+  </data>
   <data name="EpkEditor_OpenFile" xml:space="preserve">
     <value>Открыть файл EPK…</value>
   </data>
+  <data name="EpkEditor_OpenFolder" xml:space="preserve">
+    <value>Открыть папку</value>
+  </data>
   <data name="EpkEditor_Save" xml:space="preserve">
     <value>Сохранить</value>
+  </data>
+  <data name="EpkEditor_Section_ChartInfo" xml:space="preserve">
+    <value>Сведения о чарте</value>
+  </data>
+  <data name="EpkEditor_Section_Discovery" xml:space="preserve">
+    <value>Описание и обнаружение</value>
+  </data>
+  <data name="EpkEditor_Section_HiddenMode" xml:space="preserve">
+    <value>Скрытая сложность</value>
+  </data>
+  <data name="EpkEditor_Section_Identity" xml:space="preserve">
+    <value>Основные сведения</value>
+  </data>
+  <data name="EpkEditor_Section_Maps" xml:space="preserve">
+    <value>Карты</value>
   </data>
   <data name="Folder_AppLogs" xml:space="preserve">
     <value>Логи приложения</value>

--- a/src/Euterpe.Localization/XAML/XAML.zh-Hans.resx
+++ b/src/Euterpe.Localization/XAML/XAML.zh-Hans.resx
@@ -61,6 +61,30 @@
   <data name="Button_Update" xml:space="preserve">
     <value>更新</value>
   </data>
+  <data name="ChartAnalyzer_Description" xml:space="preserve">
+    <value>预测大概定数并分析谱面 Note 信息</value>
+  </data>
+  <data name="ChartAnalyzer_Title" xml:space="preserve">
+    <value>谱面分析器</value>
+  </data>
+  <data name="ChartSubmit_Description" xml:space="preserve">
+    <value>上传并发布你的谱面</value>
+  </data>
+  <data name="ChartSubmit_Title" xml:space="preserve">
+    <value>提交谱面</value>
+  </data>
+  <data name="CharterToolkit_Offline_Description" xml:space="preserve">
+    <value>在本地编辑谱面的 manifest 元数据</value>
+  </data>
+  <data name="CharterToolkit_Offline_Title" xml:space="preserve">
+    <value>离线工具</value>
+  </data>
+  <data name="CharterToolkit_Online_Description" xml:space="preserve">
+    <value>在 Euterpe 网站上分析、提交谱面（在浏览器中打开）</value>
+  </data>
+  <data name="CharterToolkit_Online_Title" xml:space="preserve">
+    <value>在线工具</value>
+  </data>
   <data name="ChartDifficulty_Easy" xml:space="preserve">
     <value>萌新</value>
   </data>
@@ -197,37 +221,40 @@
     <value>添加谱师</value>
   </data>
   <data name="EpkEditor_Field_Author" xml:space="preserve">
-    <value>作者</value>
+    <value>曲师</value>
   </data>
   <data name="EpkEditor_Field_BackgroundVideoOpacity" xml:space="preserve">
-    <value>背景视频不透明度</value>
+    <value>视频透明度</value>
   </data>
   <data name="EpkEditor_Field_Bpm" xml:space="preserve">
     <value>BPM</value>
   </data>
+  <data name="EpkEditor_Field_BpmMax" xml:space="preserve">
+    <value>最高 BPM</value>
+  </data>
+  <data name="EpkEditor_Field_BpmMin" xml:space="preserve">
+    <value>最低 BPM</value>
+  </data>
   <data name="EpkEditor_Field_Description" xml:space="preserve">
     <value>简介</value>
-  </data>
-  <data name="EpkEditor_Field_Difficulties" xml:space="preserve">
-    <value>难度</value>
   </data>
   <data name="EpkEditor_Field_Files" xml:space="preserve">
     <value>文件</value>
   </data>
   <data name="EpkEditor_Field_HideMessage" xml:space="preserve">
-    <value>隐藏提示</value>
+    <value>消息</value>
   </data>
   <data name="EpkEditor_Field_HideMode" xml:space="preserve">
-    <value>隐藏模式</value>
+    <value>模式</value>
   </data>
   <data name="EpkEditor_Field_HideRatingOverride" xml:space="preserve">
-    <value>隐藏难度值覆盖</value>
+    <value>定数显示覆盖</value>
   </data>
   <data name="EpkEditor_Field_Name" xml:space="preserve">
-    <value>名称</value>
+    <value>曲名</value>
   </data>
   <data name="EpkEditor_Field_NameRomanized" xml:space="preserve">
-    <value>罗马音名称</value>
+    <value>罗马音</value>
   </data>
   <data name="EpkEditor_Field_SafeForStreamer" xml:space="preserve">
     <value>适合直播</value>
@@ -250,8 +277,8 @@
   <data name="EpkEditor_Files_Summary" xml:space="preserve">
     <value>{0} 个文件 · {1}</value>
   </data>
-  <data name="EpkEditor_Hint_NameAuthorRequired" xml:space="preserve">
-    <value>请填写歌曲名称和作者后保存</value>
+  <data name="EpkEditor_Hint_Required" xml:space="preserve">
+    <value>请填写所有必填项后保存</value>
   </data>
   <data name="EpkEditor_Hint_TempoRange" xml:space="preserve">
     <value>请设置有效的速度范围（最小值 ≤ 最大值）</value>
@@ -262,17 +289,17 @@
   <data name="EpkEditor_Launcher_Description" xml:space="preserve">
     <value>打开并编辑谱面 manifest.epk 的元数据</value>
   </data>
-  <data name="EpkEditor_Launcher_Title" xml:space="preserve">
-    <value>EPK 元数据编辑器</value>
-  </data>
-  <data name="EpkEditor_Map_Charters" xml:space="preserve">
-    <value>谱师</value>
-  </data>
   <data name="EpkEditor_Map_Rating" xml:space="preserve">
-    <value>难度值</value>
+    <value>定数</value>
   </data>
   <data name="EpkEditor_MissingFiles" xml:space="preserve">
     <value>此谱面引用的 {0} 个文件在其文件夹中缺失</value>
+  </data>
+  <data name="EpkEditor_NewFile" xml:space="preserve">
+    <value>新建 EPK…</value>
+  </data>
+  <data name="EpkEditor_New_Description" xml:space="preserve">
+    <value>从一个放好素材的文件夹创建新谱面</value>
   </data>
   <data name="EpkEditor_OpenFile" xml:space="preserve">
     <value>打开 EPK 文件…</value>
@@ -283,17 +310,20 @@
   <data name="EpkEditor_Save" xml:space="preserve">
     <value>保存</value>
   </data>
-  <data name="EpkEditor_Section_Discovery" xml:space="preserve">
-    <value>检索</value>
+  <data name="EpkEditor_Section_ChartInfo" xml:space="preserve">
+    <value>谱面信息</value>
   </data>
-  <data name="EpkEditor_Section_Gameplay" xml:space="preserve">
-    <value>玩法</value>
+  <data name="EpkEditor_Section_Discovery" xml:space="preserve">
+    <value>描述与发现</value>
   </data>
   <data name="EpkEditor_Section_HiddenMode" xml:space="preserve">
     <value>隐藏难度</value>
   </data>
   <data name="EpkEditor_Section_Identity" xml:space="preserve">
     <value>基本信息</value>
+  </data>
+  <data name="EpkEditor_Section_Maps" xml:space="preserve">
+    <value>地图</value>
   </data>
   <data name="Folder_AppLogs" xml:space="preserve">
     <value>应用日志文件夹</value>

--- a/src/Euterpe.Localization/XAML/XAML.zh-Hant.resx
+++ b/src/Euterpe.Localization/XAML/XAML.zh-Hant.resx
@@ -61,6 +61,30 @@
   <data name="Button_Update" xml:space="preserve">
     <value>更新</value>
   </data>
+  <data name="ChartAnalyzer_Description" xml:space="preserve">
+    <value>預測大概定數並分析譜面 Note 資訊</value>
+  </data>
+  <data name="ChartAnalyzer_Title" xml:space="preserve">
+    <value>譜面分析器</value>
+  </data>
+  <data name="ChartSubmit_Description" xml:space="preserve">
+    <value>上傳並發布你的譜面</value>
+  </data>
+  <data name="ChartSubmit_Title" xml:space="preserve">
+    <value>提交譜面</value>
+  </data>
+  <data name="CharterToolkit_Offline_Description" xml:space="preserve">
+    <value>在本機編輯譜面的 manifest 元數據</value>
+  </data>
+  <data name="CharterToolkit_Offline_Title" xml:space="preserve">
+    <value>離線工具</value>
+  </data>
+  <data name="CharterToolkit_Online_Description" xml:space="preserve">
+    <value>在 Euterpe 網站上分析、提交譜面（在瀏覽器中開啟）</value>
+  </data>
+  <data name="CharterToolkit_Online_Title" xml:space="preserve">
+    <value>線上工具</value>
+  </data>
   <data name="ChartDifficulty_Easy" xml:space="preserve">
     <value>萌新</value>
   </data>
@@ -197,37 +221,40 @@
     <value>新增譜師</value>
   </data>
   <data name="EpkEditor_Field_Author" xml:space="preserve">
-    <value>作者</value>
+    <value>曲師</value>
   </data>
   <data name="EpkEditor_Field_BackgroundVideoOpacity" xml:space="preserve">
-    <value>背景影片不透明度</value>
+    <value>影片透明度</value>
   </data>
   <data name="EpkEditor_Field_Bpm" xml:space="preserve">
     <value>BPM</value>
   </data>
+  <data name="EpkEditor_Field_BpmMax" xml:space="preserve">
+    <value>最高 BPM</value>
+  </data>
+  <data name="EpkEditor_Field_BpmMin" xml:space="preserve">
+    <value>最低 BPM</value>
+  </data>
   <data name="EpkEditor_Field_Description" xml:space="preserve">
     <value>簡介</value>
-  </data>
-  <data name="EpkEditor_Field_Difficulties" xml:space="preserve">
-    <value>難度</value>
   </data>
   <data name="EpkEditor_Field_Files" xml:space="preserve">
     <value>檔案</value>
   </data>
   <data name="EpkEditor_Field_HideMessage" xml:space="preserve">
-    <value>隱藏提示</value>
+    <value>訊息</value>
   </data>
   <data name="EpkEditor_Field_HideMode" xml:space="preserve">
-    <value>隱藏模式</value>
+    <value>模式</value>
   </data>
   <data name="EpkEditor_Field_HideRatingOverride" xml:space="preserve">
-    <value>隱藏難度值覆寫</value>
+    <value>定數顯示覆蓋</value>
   </data>
   <data name="EpkEditor_Field_Name" xml:space="preserve">
-    <value>名稱</value>
+    <value>曲名</value>
   </data>
   <data name="EpkEditor_Field_NameRomanized" xml:space="preserve">
-    <value>羅馬音名稱</value>
+    <value>羅馬音</value>
   </data>
   <data name="EpkEditor_Field_SafeForStreamer" xml:space="preserve">
     <value>適合直播</value>
@@ -250,8 +277,8 @@
   <data name="EpkEditor_Files_Summary" xml:space="preserve">
     <value>{0} 個檔案 · {1}</value>
   </data>
-  <data name="EpkEditor_Hint_NameAuthorRequired" xml:space="preserve">
-    <value>請填寫歌曲名稱與作者後儲存</value>
+  <data name="EpkEditor_Hint_Required" xml:space="preserve">
+    <value>請填寫所有必填項後儲存</value>
   </data>
   <data name="EpkEditor_Hint_TempoRange" xml:space="preserve">
     <value>請設定有效的速度範圍（最小值 ≤ 最大值）</value>
@@ -262,17 +289,17 @@
   <data name="EpkEditor_Launcher_Description" xml:space="preserve">
     <value>開啟並編輯譜面 manifest.epk 的元數據</value>
   </data>
-  <data name="EpkEditor_Launcher_Title" xml:space="preserve">
-    <value>EPK 元數據編輯器</value>
-  </data>
-  <data name="EpkEditor_Map_Charters" xml:space="preserve">
-    <value>譜師</value>
-  </data>
   <data name="EpkEditor_Map_Rating" xml:space="preserve">
-    <value>難度值</value>
+    <value>定數</value>
   </data>
   <data name="EpkEditor_MissingFiles" xml:space="preserve">
     <value>此譜面引用的 {0} 個檔案在其資料夾中遺失</value>
+  </data>
+  <data name="EpkEditor_NewFile" xml:space="preserve">
+    <value>新建 EPK…</value>
+  </data>
+  <data name="EpkEditor_New_Description" xml:space="preserve">
+    <value>從一個放好素材的資料夾建立新譜面</value>
   </data>
   <data name="EpkEditor_OpenFile" xml:space="preserve">
     <value>開啟 EPK 檔案…</value>
@@ -283,17 +310,20 @@
   <data name="EpkEditor_Save" xml:space="preserve">
     <value>儲存</value>
   </data>
-  <data name="EpkEditor_Section_Discovery" xml:space="preserve">
-    <value>檢索</value>
+  <data name="EpkEditor_Section_ChartInfo" xml:space="preserve">
+    <value>譜面資訊</value>
   </data>
-  <data name="EpkEditor_Section_Gameplay" xml:space="preserve">
-    <value>玩法</value>
+  <data name="EpkEditor_Section_Discovery" xml:space="preserve">
+    <value>描述與發現</value>
   </data>
   <data name="EpkEditor_Section_HiddenMode" xml:space="preserve">
     <value>隱藏難度</value>
   </data>
   <data name="EpkEditor_Section_Identity" xml:space="preserve">
     <value>基本資訊</value>
+  </data>
+  <data name="EpkEditor_Section_Maps" xml:space="preserve">
+    <value>地圖</value>
   </data>
   <data name="Folder_AppLogs" xml:space="preserve">
     <value>應用程式記錄檔</value>

--- a/src/Euterpe/Features/Charting/CharterToolkitPanel.axaml
+++ b/src/Euterpe/Features/Charting/CharterToolkitPanel.axaml
@@ -22,13 +22,152 @@
             Classes="ContentListRoot"
             IsVisible="{Binding ActiveTool, Converter={x:Static ObjectConverters.IsNull}}">
             <e:LabeledSection
-                Description="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Launcher_Description}}"
-                Title="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Launcher_Title}}">
-                <Button
-                    Classes="Primary"
-                    Command="{Binding OpenEpkEditorCommand}"
-                    Content="{Localize {x:Static loc:XAMLLiteral.EpkEditor_OpenFile}}"
-                    HorizontalAlignment="Left" />
+                Description="{Localize {x:Static loc:XAMLLiteral.CharterToolkit_Offline_Description}}"
+                Title="{Localize {x:Static loc:XAMLLiteral.CharterToolkit_Offline_Title}}">
+                <Grid
+                    ColumnDefinitions="*,16,*"
+                    MaxWidth="820">
+                    <!--  New: create a manifest in a folder of assets  -->
+                    <Button
+                        Classes="Transparent Card"
+                        Command="{Binding NewEpkEditorCommand}"
+                        Grid.Column="0">
+                        <Button.Styles>
+                            <Style
+                                Selector="Button:pointerover Border.Hover">
+                                <Setter Property="Background" Value="#047857" />
+                                <Setter Property="RenderTransform" Value="scale(1.01)" />
+                            </Style>
+                        </Button.Styles>
+                        <Border
+                            Classes="Hover">
+                            <StackPanel>
+                                <TextBlock
+                                    Classes="CardTitle"
+                                    Text="{Localize {x:Static loc:XAMLLiteral.EpkEditor_NewFile}}">
+                                    <TextBlock.Foreground>
+                                        <LinearGradientBrush StartPoint="0%,0%" EndPoint="100%,100%">
+                                            <GradientStop Offset="0" Color="#34D399" />
+                                            <GradientStop Offset="1" Color="#059669" />
+                                        </LinearGradientBrush>
+                                    </TextBlock.Foreground>
+                                </TextBlock>
+                                <TextBlock
+                                    Classes="CardDesc"
+                                    Text="{Localize {x:Static loc:XAMLLiteral.EpkEditor_New_Description}}" />
+                            </StackPanel>
+                        </Border>
+                    </Button>
+
+                    <!--  Open: edit an existing chart's manifest.epk  -->
+                    <Button
+                        Classes="Transparent Card"
+                        Command="{Binding OpenEpkEditorCommand}"
+                        Grid.Column="2">
+                        <Button.Styles>
+                            <Style
+                                Selector="Button:pointerover Border.Hover">
+                                <Setter Property="Background" Value="#4B49AC" />
+                                <Setter Property="RenderTransform" Value="scale(1.01)" />
+                            </Style>
+                        </Button.Styles>
+                        <Border
+                            Classes="Hover">
+                            <StackPanel>
+                                <TextBlock
+                                    Classes="CardTitle"
+                                    Text="{Localize {x:Static loc:XAMLLiteral.EpkEditor_OpenFile}}">
+                                    <TextBlock.Foreground>
+                                        <LinearGradientBrush StartPoint="0%,0%" EndPoint="100%,100%">
+                                            <GradientStop Offset="0" Color="#818CF8" />
+                                            <GradientStop Offset="1" Color="#6366F1" />
+                                        </LinearGradientBrush>
+                                    </TextBlock.Foreground>
+                                </TextBlock>
+                                <TextBlock
+                                    Classes="CardDesc"
+                                    Text="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Launcher_Description}}" />
+                            </StackPanel>
+                        </Border>
+                    </Button>
+                </Grid>
+            </e:LabeledSection>
+
+            <!--  Online tools open the Euterpe website in the browser  -->
+            <e:LabeledSection
+                Description="{Localize {x:Static loc:XAMLLiteral.CharterToolkit_Online_Description}}"
+                Title="{Localize {x:Static loc:XAMLLiteral.CharterToolkit_Online_Title}}">
+                <Grid
+                    ColumnDefinitions="*,16,*"
+                    MaxWidth="820">
+                    <!--  Chart Analyzer: predict ratings, analyse Notes  -->
+                    <Button
+                        Classes="Transparent Card"
+                        Command="{Binding OpenUrlCommand}"
+                        CommandParameter="https://euterpe-org.com/chart-analyzer"
+                        Grid.Column="0"
+                        ToolTip.Tip="https://euterpe-org.com/chart-analyzer">
+                        <Button.Styles>
+                            <Style
+                                Selector="Button:pointerover Border.Hover">
+                                <Setter Property="Background" Value="#9A3412" />
+                                <Setter Property="RenderTransform" Value="scale(1.01)" />
+                            </Style>
+                        </Button.Styles>
+                        <Border
+                            Classes="Hover">
+                            <StackPanel>
+                                <TextBlock
+                                    Classes="CardTitle"
+                                    Text="{Localize {x:Static loc:XAMLLiteral.ChartAnalyzer_Title}}">
+                                    <TextBlock.Foreground>
+                                        <LinearGradientBrush StartPoint="0%,0%" EndPoint="100%,100%">
+                                            <GradientStop Offset="0" Color="#FB923C" />
+                                            <GradientStop Offset="1" Color="#EA580C" />
+                                        </LinearGradientBrush>
+                                    </TextBlock.Foreground>
+                                </TextBlock>
+                                <TextBlock
+                                    Classes="CardDesc"
+                                    Text="{Localize {x:Static loc:XAMLLiteral.ChartAnalyzer_Description}}" />
+                            </StackPanel>
+                        </Border>
+                    </Button>
+
+                    <!--  Submit Chart: upload and publish on the platform  -->
+                    <Button
+                        Classes="Transparent Card"
+                        Command="{Binding OpenUrlCommand}"
+                        CommandParameter="https://euterpe-org.com/workspace/charts/new"
+                        Grid.Column="2"
+                        ToolTip.Tip="https://euterpe-org.com/workspace/charts/new">
+                        <Button.Styles>
+                            <Style
+                                Selector="Button:pointerover Border.Hover">
+                                <Setter Property="Background" Value="#9F1239" />
+                                <Setter Property="RenderTransform" Value="scale(1.01)" />
+                            </Style>
+                        </Button.Styles>
+                        <Border
+                            Classes="Hover">
+                            <StackPanel>
+                                <TextBlock
+                                    Classes="CardTitle"
+                                    Text="{Localize {x:Static loc:XAMLLiteral.ChartSubmit_Title}}">
+                                    <TextBlock.Foreground>
+                                        <LinearGradientBrush StartPoint="0%,0%" EndPoint="100%,100%">
+                                            <GradientStop Offset="0" Color="#FB7185" />
+                                            <GradientStop Offset="1" Color="#E11D48" />
+                                        </LinearGradientBrush>
+                                    </TextBlock.Foreground>
+                                </TextBlock>
+                                <TextBlock
+                                    Classes="CardDesc"
+                                    Text="{Localize {x:Static loc:XAMLLiteral.ChartSubmit_Description}}" />
+                            </StackPanel>
+                        </Border>
+                    </Button>
+                </Grid>
             </e:LabeledSection>
         </StackPanel>
 

--- a/src/Euterpe/Features/Charting/CharterToolkitPanelViewModel.cs
+++ b/src/Euterpe/Features/Charting/CharterToolkitPanelViewModel.cs
@@ -26,6 +26,47 @@ public sealed partial class CharterToolkitPanelViewModel : ViewModelBase
         }
     }
 
+    [RelayCommand]
+    private async Task NewEpkEditorAsync()
+    {
+        if (await FileSystemPickerService.GetSingleFolderPathAsync(FolderDialog_Title_ChooseChartFolder).ConfigureAwait(true) is not { } folder)
+        {
+            return;
+        }
+
+        var present = FileSystemService.GetFileSizes(folder);
+        if (present.ContainsKey(ChartFiles.ManifestFileName))
+        {
+            await OpenEpkAsync(Path.Combine(folder, ChartFiles.ManifestFileName)).ConfigureAwait(true);
+            return;
+        }
+
+        var files = new Dictionary<string, ManifestFileEntry>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (name, size) in present)
+        {
+            if (name.EndsWith(".tmp", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            files[name] = new ManifestFileEntry { Version = 1, Size = size };
+        }
+
+        Editor.Open(Path.Combine(folder, ChartFiles.ManifestFileName), new Manifest
+        {
+            Schema = Manifest.CurrentSchema,
+            Meta = new ManifestMeta
+            {
+                Name = string.Empty,
+                Author = string.Empty,
+                Scene = "scene_01",
+                Maps = new Dictionary<string, ManifestMap>(StringComparer.OrdinalIgnoreCase)
+            },
+            Files = files
+        });
+        ActiveTool = Editor;
+    }
+
     public async Task OpenEpkAsync(string filePath)
     {
         Manifest manifest;
@@ -60,6 +101,7 @@ public sealed partial class CharterToolkitPanelViewModel : ViewModelBase
     public required IChartManageService ChartManageService { get; init; }
     public required EpkEditorPanelViewModel Editor { get; init; }
     public required IFileSystemPickerService FileSystemPickerService { get; init; }
+    public required IFileSystemService FileSystemService { get; init; }
     public required ILogger<CharterToolkitPanelViewModel> Logger { get; init; }
     public required IMessagePackSerializationService MessagePackSerialization { get; init; }
     public required INotificationService NotificationService { get; init; }

--- a/src/Euterpe/Features/Charting/EpkEditorPanel.axaml
+++ b/src/Euterpe/Features/Charting/EpkEditorPanel.axaml
@@ -19,69 +19,90 @@
         <vm:EpkEditorPanelViewModel />
     </Design.DataContext>
 
+    <UserControl.KeyBindings>
+        <KeyBinding
+            Command="{Binding SaveCommand}"
+            Gesture="Ctrl+S" />
+    </UserControl.KeyBindings>
+
     <UserControl.Styles>
         <Style
-            Selector="u|Form">
-            <Setter Property="LabelPosition" Value="Left" />
-            <Setter Property="LabelWidth" Value="128" />
-        </Style>
-        <Style
-            Selector="Border.Section">
+            Selector="Border.Card">
             <Setter Property="Background" Value="{DynamicResource SecondaryCardColor}" />
             <Setter Property="CornerRadius" Value="8" />
             <Setter Property="Padding" Value="20" />
+            <Setter Property="VerticalAlignment" Value="Top" />
         </Style>
         <Style
-            Selector="TextBlock.GroupTitle">
+            Selector="TextBlock.SectionTitle">
             <Setter Property="FontSize" Value="15" />
             <Setter Property="FontWeight" Value="SemiBold" />
         </Style>
         <Style
-            Selector="TextBlock.ColumnHeader">
-            <Setter Property="FontSize" Value="12" />
+            Selector="TextBlock.FieldLabel">
+            <Setter Property="FontSize" Value="13" />
             <Setter Property="Foreground" Value="{DynamicResource SemiColorText2}" />
-            <Setter Property="VerticalAlignment" Value="Center" />
+        </Style>
+        <!--  Give chips room from the tag box's top-left edge  -->
+        <Style
+            Selector="u|TagInput /template/ Border#PART_RootBorder">
+            <Setter Property="Padding" Value="2,2,0,0" />
+        </Style>
+        <!--  Each field stacks its label above the input with room to breathe  -->
+        <Style
+            Selector="StackPanel.Field">
+            <Setter Property="Spacing" Value="6" />
         </Style>
     </UserControl.Styles>
 
     <Grid
         RowDefinitions="Auto,*,Auto">
 
-        <!--  Context header: leave, identity, reveal folder  -->
+        <!--  Document header: close, identity, reveal folder  -->
         <Border
             Grid.Row="0"
             BorderBrush="{DynamicResource BorderBrush}"
             BorderThickness="0,0,0,1"
-            Padding="16,12">
+            Padding="16,10">
             <Grid
                 ColumnDefinitions="Auto,Auto,*,Auto">
-                <u:IconButton
-                    Grid.Column="0"
+                <Button
+                    Classes="Transparent"
                     Command="{Binding BackCommand}"
-                    Content="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Back}}"
-                    Icon="{StaticResource SemiIconChevronLeft}"
-                    IconPlacement="Left"
-                    VerticalAlignment="Center" />
+                    Grid.Column="0"
+                    Padding="8,6"
+                    VerticalAlignment="Center">
+                    <StackPanel
+                        Orientation="Horizontal"
+                        Spacing="4">
+                        <PathIcon
+                            Data="{StaticResource SemiIconChevronLeft}"
+                            Height="16"
+                            Width="16" />
+                        <TextBlock
+                            Text="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Back}}" />
+                    </StackPanel>
+                </Button>
 
                 <Border
                     Grid.Column="1"
                     Background="{DynamicResource SemiColorFill0}"
                     ClipToBounds="True"
                     CornerRadius="8"
-                    Height="56"
+                    Height="48"
                     Margin="16,0,12,0"
                     VerticalAlignment="Center"
-                    Width="56">
+                    Width="48">
                     <Panel>
                         <PathIcon
                             Data="{StaticResource SemiIconMusic}"
                             Foreground="{DynamicResource SemiColorText2}"
-                            Height="20"
+                            Height="18"
                             Opacity="0.4"
-                            Width="20" />
+                            Width="18" />
                         <e:AsyncImage
                             Background="{Binding CoverDominantColor, Converter={x:Static converters:FuncValueConverters.HexColorToBrushConverter}}"
-                            DecodeWidth="56"
+                            DecodeWidth="48"
                             Source="{Binding CoverPath}"
                             Stretch="UniformToFill" />
                     </Panel>
@@ -91,289 +112,417 @@
                     Grid.Column="2"
                     Spacing="2"
                     VerticalAlignment="Center">
-                    <TextBlock
-                        FontSize="18"
-                        FontWeight="SemiBold"
-                        MaxLines="1"
-                        Text="{Binding Name}"
-                        TextTrimming="CharacterEllipsis" />
+                    <StackPanel
+                        Orientation="Horizontal"
+                        Spacing="6">
+                        <TextBlock
+                            FontSize="16"
+                            FontWeight="SemiBold"
+                            MaxLines="1"
+                            Text="{Binding Name}"
+                            TextTrimming="CharacterEllipsis" />
+                        <TextBlock
+                            FontSize="14"
+                            Foreground="{DynamicResource SemiColorText0}"
+                            IsVisible="{Binding IsDirty}"
+                            Text="●"
+                            VerticalAlignment="Center" />
+                    </StackPanel>
                     <TextBlock
                         FontSize="12"
                         Foreground="{DynamicResource SemiColorText2}"
                         MaxLines="1"
-                        Text="{Binding Author}"
-                        TextTrimming="CharacterEllipsis" />
+                        Text="{Binding FilePath}"
+                        TextTrimming="CharacterEllipsis"
+                        ToolTip.Tip="{Binding FilePath}" />
                 </StackPanel>
 
-                <u:IconButton
-                    Grid.Column="3"
+                <Button
+                    Classes="Transparent"
                     Command="{Binding OpenFolderCommand}"
                     CommandParameter="{Binding FolderPath}"
-                    Icon="{StaticResource SemiIconFolderOpen}"
+                    Grid.Column="3"
                     IsEnabled="{Binding FolderPath, Converter={x:Static ObjectConverters.IsNotNull}}"
+                    Padding="8"
                     ToolTip.Tip="{Localize {x:Static loc:XAMLLiteral.EpkEditor_OpenFolder}}"
-                    VerticalAlignment="Center" />
+                    VerticalAlignment="Center">
+                    <PathIcon
+                        Data="{StaticResource SemiIconFolderOpen}"
+                        Height="16"
+                        Width="16" />
+                </Button>
             </Grid>
         </Border>
 
-        <!--  Editable metadata, grouped into cards  -->
+        <!--  Editable metadata: uniform cards in two filling, independent columns  -->
         <ScrollViewer
             Grid.Row="1">
             <StackPanel
-                Margin="16"
+                HorizontalAlignment="Stretch"
+                Margin="20"
+                MaxWidth="1200"
                 Spacing="16">
 
                 <!--  Files referenced by the manifest but absent from the folder  -->
                 <u:Banner
                     CanClose="False"
                     Content="{Binding MissingFilesMessage}"
+                    CornerRadius="8"
                     IsVisible="{Binding HasMissingFiles}"
                     Type="Warning" />
 
-                <!--  Identity  -->
-                <Border
-                    Classes="Section">
-                    <StackPanel
-                        Spacing="16">
-                        <TextBlock
-                            Classes="GroupTitle"
-                            Text="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Section_Identity}}" />
-                        <u:Form>
-                            <TextBox
-                                Text="{Binding Name}"
-                                u:FormItem.IsRequired="True"
-                                u:FormItem.Label="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Field_Name}}" />
-                            <TextBox
-                                Text="{Binding NameRomanized}"
-                                u:FormItem.Label="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Field_NameRomanized}}" />
-                            <TextBox
-                                Text="{Binding Author}"
-                                u:FormItem.IsRequired="True"
-                                u:FormItem.Label="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Field_Author}}" />
-                            <TextBox
-                                AcceptsReturn="True"
-                                MinHeight="76"
-                                Text="{Binding Description}"
-                                TextWrapping="Wrap"
-                                u:FormItem.Label="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Field_Description}}" />
-                        </u:Form>
-                    </StackPanel>
-                </Border>
+                <Grid
+                    ColumnDefinitions="*,16,*">
 
-                <!--  Gameplay  -->
-                <Border
-                    Classes="Section">
+                    <!--  Left column  -->
                     <StackPanel
+                        Grid.Column="0"
                         Spacing="16">
-                        <TextBlock
-                            Classes="GroupTitle"
-                            Text="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Section_Gameplay}}" />
-                        <u:Form>
-                            <!--  Base tempo, plus an optional variable-tempo range  -->
+
+                        <!--  Basic info  -->
+                        <Border
+                            Classes="Card">
                             <StackPanel
-                                Spacing="8"
-                                u:FormItem.Label="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Field_Bpm}}">
-                                <StackPanel
-                                    Orientation="Horizontal"
-                                    Spacing="12">
-                                    <u:NumericIntUpDown
-                                        Maximum="999"
-                                        Minimum="0"
-                                        Value="{Binding Bpm}"
-                                        Width="140" />
-                                    <ToggleSwitch
-                                        Content="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Field_TempoVariable}}"
-                                        IsChecked="{Binding IsBpmRange, Mode=TwoWay}"
-                                        VerticalAlignment="Center" />
-                                </StackPanel>
-                                <StackPanel
-                                    IsVisible="{Binding IsBpmRange}"
-                                    Orientation="Horizontal"
-                                    Spacing="8">
-                                    <u:NumericIntUpDown
-                                        Maximum="999"
-                                        Minimum="0"
-                                        Value="{Binding BpmMin}"
-                                        Width="120" />
-                                    <TextBlock
-                                        Text="–"
-                                        VerticalAlignment="Center" />
-                                    <u:NumericIntUpDown
-                                        Maximum="999"
-                                        Minimum="0"
-                                        Value="{Binding BpmMax}"
-                                        Width="120" />
-                                </StackPanel>
-                            </StackPanel>
-                            <TextBox
-                                Text="{Binding Scene}"
-                                u:FormItem.Label="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Field_Scene}}" />
-                            <TextBox
-                                Text="{Binding SceneEgg}"
-                                u:FormItem.Label="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Field_SceneEgg}}" />
-                        </u:Form>
-                        <!--  Opacity only matters when the chart ships a background video  -->
-                        <u:Form
-                            IsVisible="{Binding HasVideo}">
-                            <u:NumericFloatUpDown
-                                Maximum="1"
-                                Minimum="0"
-                                Step="0.1"
-                                Value="{Binding BackgroundVideoOpacity}"
-                                Width="140"
-                                u:FormItem.Label="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Field_BackgroundVideoOpacity}}" />
-                        </u:Form>
-                    </StackPanel>
-                </Border>
-
-                <!--  Per-difficulty rating and charters  -->
-                <Border
-                    Classes="Section">
-                    <StackPanel
-                        Spacing="12">
-                        <TextBlock
-                            Classes="GroupTitle"
-                            Text="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Field_Difficulties}}" />
-                        <Grid
-                            ColumnDefinitions="40,110,80,*">
-                            <TextBlock
-                                Classes="ColumnHeader"
-                                Grid.Column="2"
-                                Text="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Map_Rating}}" />
-                            <TextBlock
-                                Classes="ColumnHeader"
-                                Grid.Column="3"
-                                Margin="10,0,0,0"
-                                Text="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Map_Charters}}" />
-                        </Grid>
-                        <ItemsControl
-                            ItemsSource="{Binding Maps}">
-                            <ItemsControl.ItemsPanel>
-                                <ItemsPanelTemplate>
-                                    <StackPanel
-                                        Spacing="10" />
-                                </ItemsPanelTemplate>
-                            </ItemsControl.ItemsPanel>
-                            <ItemsControl.ItemTemplate>
-                                <DataTemplate
-                                    x:DataType="vm:DifficultyEditViewModel">
-                                    <Grid
-                                        ColumnDefinitions="40,110,80,*">
-                                        <Image
-                                            Grid.Column="0"
-                                            Height="28"
-                                            Source="{Binding Difficulty, Converter={x:Static converters:FuncValueConverters.DifficultyIconConverter}}"
-                                            VerticalAlignment="Center"
-                                            Width="28" />
-                                        <TextBlock
-                                            Grid.Column="1"
-                                            Text="{Binding DifficultyName.Value}"
-                                            VerticalAlignment="Center" />
-                                        <TextBox
-                                            Grid.Column="2"
-                                            PlaceholderText="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Map_Rating}}"
-                                            Text="{Binding Rating}"
-                                            Width="64" />
-                                        <u:TagInput
-                                            Grid.Column="3"
-                                            LostFocusBehavior="Add"
-                                            Margin="10,0,0,0"
-                                            PlaceholderText="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Charters_Watermark}}"
-                                            Separator=","
-                                            Tags="{Binding Charters}"
-                                            VerticalAlignment="Center" />
-                                    </Grid>
-                                </DataTemplate>
-                            </ItemsControl.ItemTemplate>
-                        </ItemsControl>
-                    </StackPanel>
-                </Border>
-
-                <!--  Hidden-difficulty (map4) settings; only when the chart has a Hidden map  -->
-                <Border
-                    Classes="Section"
-                    IsVisible="{Binding HasHiddenDifficulty}">
-                    <StackPanel
-                        Spacing="16">
-                        <TextBlock
-                            Classes="GroupTitle"
-                            Text="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Section_HiddenMode}}" />
-                        <u:Form>
-                            <TextBox
-                                Text="{Binding HideMode}"
-                                u:FormItem.Label="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Field_HideMode}}" />
-                            <TextBox
-                                Text="{Binding HideRatingOverride}"
-                                u:FormItem.Label="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Field_HideRatingOverride}}" />
-                            <TextBox
-                                Text="{Binding HideMessage}"
-                                u:FormItem.Label="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Field_HideMessage}}" />
-                        </u:Form>
-                    </StackPanel>
-                </Border>
-
-                <!--  Discovery  -->
-                <Border
-                    Classes="Section">
-                    <StackPanel
-                        Spacing="16">
-                        <TextBlock
-                            Classes="GroupTitle"
-                            Text="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Section_Discovery}}" />
-                        <u:Form>
-                            <ToggleSwitch
-                                IsChecked="{Binding SafeForStreamer, Mode=TwoWay}"
-                                u:FormItem.Label="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Field_SafeForStreamer}}" />
-                            <u:TagInput
-                                LostFocusBehavior="Add"
-                                PlaceholderText="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Keywords_Watermark}}"
-                                Separator=","
-                                Tags="{Binding SearchKeywords}"
-                                u:FormItem.Label="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Field_SearchKeywords}}" />
-                        </u:Form>
-                    </StackPanel>
-                </Border>
-
-                <!--  Files are read-only; Refresh re-reads them from the chart folder  -->
-                <Expander
-                    Header="{Binding FilesSummary}">
-                    <StackPanel
-                        Spacing="8">
-                        <Button
-                            Command="{Binding RefreshFilesCommand}"
-                            HorizontalAlignment="Right">
-                            <StackPanel
-                                Orientation="Horizontal"
-                                Spacing="6">
-                                <PathIcon
-                                    Data="{StaticResource SemiIconRefresh}"
-                                    Height="14"
-                                    Width="14" />
+                                Spacing="16">
                                 <TextBlock
-                                    Text="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Files_Refresh}}" />
+                                    Classes="SectionTitle"
+                                    Text="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Section_Identity}}" />
+                                <StackPanel
+                                    Classes="Field">
+                                    <StackPanel
+                                        Orientation="Horizontal"
+                                        Spacing="2">
+                                        <TextBlock
+                                            Classes="FieldLabel"
+                                            Text="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Field_Name}}" />
+                                        <TextBlock
+                                            Foreground="{DynamicResource SemiColorDanger}"
+                                            Text="*" />
+                                    </StackPanel>
+                                    <TextBox
+                                        Text="{Binding Name}" />
+                                </StackPanel>
+                                <StackPanel
+                                    Classes="Field">
+                                    <StackPanel
+                                        Orientation="Horizontal"
+                                        Spacing="2">
+                                        <TextBlock
+                                            Classes="FieldLabel"
+                                            Text="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Field_Author}}" />
+                                        <TextBlock
+                                            Foreground="{DynamicResource SemiColorDanger}"
+                                            Text="*" />
+                                    </StackPanel>
+                                    <TextBox
+                                        Text="{Binding Author}" />
+                                </StackPanel>
+                                <StackPanel
+                                    Classes="Field">
+                                    <TextBlock
+                                        Classes="FieldLabel"
+                                        Text="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Field_NameRomanized}}" />
+                                    <TextBox
+                                        Text="{Binding NameRomanized}" />
+                                </StackPanel>
                             </StackPanel>
-                        </Button>
-                        <ItemsControl
-                            ItemsSource="{Binding Files}">
-                            <ItemsControl.ItemTemplate>
-                                <DataTemplate
-                                    x:DataType="models:EpkFileEntry">
-                                    <Grid
-                                        ColumnDefinitions="*,Auto"
-                                        Margin="0,0,0,2">
-                                        <TextBlock
-                                            Grid.Column="0"
-                                            Text="{Binding Name}" />
-                                        <TextBlock
-                                            Foreground="{DynamicResource SemiColorText2}"
-                                            Grid.Column="1"
-                                            Text="{Binding SizeDisplay}" />
-                                    </Grid>
-                                </DataTemplate>
-                            </ItemsControl.ItemTemplate>
-                        </ItemsControl>
+                        </Border>
+
+                        <!--  Description and discovery  -->
+                        <Border
+                            Classes="Card">
+                            <StackPanel
+                                Spacing="16">
+                                <TextBlock
+                                    Classes="SectionTitle"
+                                    Text="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Section_Discovery}}" />
+                                <StackPanel
+                                    Classes="Field">
+                                    <TextBlock
+                                        Classes="FieldLabel"
+                                        Text="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Field_Description}}" />
+                                    <TextBox
+                                        AcceptsReturn="True"
+                                        Height="104"
+                                        Padding="10,8"
+                                        Text="{Binding Description}"
+                                        TextWrapping="Wrap"
+                                        VerticalContentAlignment="Top" />
+                                </StackPanel>
+                                <Grid
+                                    ColumnDefinitions="*,Auto">
+                                    <TextBlock
+                                        Classes="FieldLabel"
+                                        Grid.Column="0"
+                                        Text="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Field_SafeForStreamer}}"
+                                        VerticalAlignment="Center" />
+                                    <ToggleSwitch
+                                        Grid.Column="1"
+                                        IsChecked="{Binding SafeForStreamer, Mode=TwoWay}" />
+                                </Grid>
+                                <StackPanel
+                                    Classes="Field">
+                                    <TextBlock
+                                        Classes="FieldLabel"
+                                        Text="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Field_SearchKeywords}}" />
+                                    <u:TagInput
+                                        LostFocusBehavior="Add"
+                                        PlaceholderText="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Keywords_Watermark}}"
+                                        Separator=","
+                                        Tags="{Binding SearchKeywords}" />
+                                </StackPanel>
+                            </StackPanel>
+                        </Border>
+
+                        <!--  Files are read-only; Refresh re-reads them from the chart folder  -->
+                        <Border
+                            Classes="Card">
+                            <StackPanel
+                                Spacing="12">
+                                <Grid
+                                    ColumnDefinitions="*,Auto">
+                                    <TextBlock
+                                        Classes="SectionTitle"
+                                        Grid.Column="0"
+                                        Text="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Field_Files}}"
+                                        VerticalAlignment="Center" />
+                                    <Button
+                                        Classes="Transparent"
+                                        Command="{Binding RefreshFilesCommand}"
+                                        Grid.Column="1"
+                                        Padding="8,4">
+                                        <StackPanel
+                                            Orientation="Horizontal"
+                                            Spacing="6">
+                                            <PathIcon
+                                                Data="{StaticResource SemiIconRefresh}"
+                                                Height="14"
+                                                Width="14" />
+                                            <TextBlock
+                                                Text="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Files_Refresh}}" />
+                                        </StackPanel>
+                                    </Button>
+                                </Grid>
+                                <TextBlock
+                                    Classes="FieldLabel"
+                                    Text="{Binding FilesSummary}" />
+                                <ItemsControl
+                                    ItemsSource="{Binding Files}">
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate
+                                            x:DataType="models:EpkFileEntry">
+                                            <Grid
+                                                ColumnDefinitions="*,Auto"
+                                                Margin="0,0,0,2">
+                                                <TextBlock
+                                                    Grid.Column="0"
+                                                    Text="{Binding Name}" />
+                                                <TextBlock
+                                                    Foreground="{DynamicResource SemiColorText2}"
+                                                    Grid.Column="1"
+                                                    Text="{Binding SizeDisplay}" />
+                                            </Grid>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                            </StackPanel>
+                        </Border>
                     </StackPanel>
-                </Expander>
+
+                    <!--  Right column  -->
+                    <StackPanel
+                        Grid.Column="2"
+                        Spacing="16">
+
+                        <!--  Chart info: tempo and stage  -->
+                        <Border
+                            Classes="Card">
+                            <StackPanel
+                                Spacing="16">
+                                <TextBlock
+                                    Classes="SectionTitle"
+                                    Text="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Section_ChartInfo}}" />
+                                <StackPanel
+                                    Classes="Field">
+                                    <StackPanel
+                                        Orientation="Horizontal"
+                                        Spacing="2">
+                                        <TextBlock
+                                            Classes="FieldLabel"
+                                            Text="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Field_Scene}}" />
+                                        <TextBlock
+                                            Foreground="{DynamicResource SemiColorDanger}"
+                                            Text="*" />
+                                    </StackPanel>
+                                    <TextBox
+                                        Text="{Binding Scene}" />
+                                </StackPanel>
+                                <StackPanel
+                                    Classes="Field">
+                                    <TextBlock
+                                        Classes="FieldLabel"
+                                        Text="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Field_SceneEgg}}" />
+                                    <TextBox
+                                        Text="{Binding SceneEgg}" />
+                                </StackPanel>
+                                <StackPanel
+                                    Spacing="8">
+                                    <StackPanel
+                                        Classes="Field">
+                                        <StackPanel
+                                            Orientation="Horizontal"
+                                            Spacing="2">
+                                            <TextBlock
+                                                Classes="FieldLabel"
+                                                Text="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Field_Bpm}}" />
+                                            <TextBlock
+                                                Foreground="{DynamicResource SemiColorDanger}"
+                                                Text="*" />
+                                        </StackPanel>
+                                        <u:NumericIntUpDown
+                                            Maximum="999"
+                                            Minimum="0"
+                                            Value="{Binding Bpm}" />
+                                    </StackPanel>
+                                    <Grid
+                                        ColumnDefinitions="*,Auto">
+                                        <TextBlock
+                                            Classes="FieldLabel"
+                                            Grid.Column="0"
+                                            Text="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Field_TempoVariable}}"
+                                            VerticalAlignment="Center" />
+                                        <ToggleSwitch
+                                            Grid.Column="1"
+                                            IsChecked="{Binding IsBpmRange, Mode=TwoWay}" />
+                                    </Grid>
+                                    <Grid
+                                        ColumnDefinitions="*,Auto,*"
+                                        IsVisible="{Binding IsBpmRange}">
+                                        <u:NumericIntUpDown
+                                            Grid.Column="0"
+                                            Maximum="999"
+                                            Minimum="0"
+                                            PlaceholderText="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Field_BpmMin}}"
+                                            Value="{Binding BpmMin}" />
+                                        <TextBlock
+                                            Grid.Column="1"
+                                            Margin="8,0"
+                                            Text="–"
+                                            VerticalAlignment="Center" />
+                                        <u:NumericIntUpDown
+                                            Grid.Column="2"
+                                            Maximum="999"
+                                            Minimum="0"
+                                            PlaceholderText="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Field_BpmMax}}"
+                                            Value="{Binding BpmMax}" />
+                                    </Grid>
+                                </StackPanel>
+                                <StackPanel
+                                    Classes="Field"
+                                    IsVisible="{Binding HasVideo}">
+                                    <TextBlock
+                                        Classes="FieldLabel"
+                                        Text="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Field_BackgroundVideoOpacity}}" />
+                                    <u:NumericFloatUpDown
+                                        HorizontalAlignment="Left"
+                                        Maximum="1"
+                                        Minimum="0"
+                                        Step="0.1"
+                                        Value="{Binding BackgroundVideoOpacity}"
+                                        Width="150" />
+                                </StackPanel>
+                            </StackPanel>
+                        </Border>
+
+                        <!--  Per-map rating and charters  -->
+                        <Border
+                            Classes="Card">
+                            <StackPanel
+                                Spacing="12">
+                                <TextBlock
+                                    Classes="SectionTitle"
+                                    Text="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Section_Maps}}" />
+                                <ItemsControl
+                                    ItemsSource="{Binding Maps}">
+                                    <ItemsControl.ItemsPanel>
+                                        <ItemsPanelTemplate>
+                                            <StackPanel
+                                                Spacing="10" />
+                                        </ItemsPanelTemplate>
+                                    </ItemsControl.ItemsPanel>
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate
+                                            x:DataType="vm:DifficultyEditViewModel">
+                                            <Grid
+                                                ColumnDefinitions="36,Auto,64,*">
+                                                <Image
+                                                    Grid.Column="0"
+                                                    Height="28"
+                                                    Source="{Binding Difficulty, Converter={x:Static converters:FuncValueConverters.DifficultyIconConverter}}"
+                                                    VerticalAlignment="Center"
+                                                    Width="28" />
+                                                <TextBlock
+                                                    Grid.Column="1"
+                                                    Margin="0,0,12,0"
+                                                    Text="{Binding DifficultyName.Value}"
+                                                    VerticalAlignment="Center" />
+                                                <TextBox
+                                                    Grid.Column="2"
+                                                    PlaceholderText="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Map_Rating}}"
+                                                    Text="{Binding Rating}"
+                                                    VerticalAlignment="Center" />
+                                                <u:TagInput
+                                                    Grid.Column="3"
+                                                    LostFocusBehavior="Add"
+                                                    Margin="10,0,0,0"
+                                                    PlaceholderText="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Charters_Watermark}}"
+                                                    Separator=","
+                                                    Tags="{Binding Charters}"
+                                                    VerticalAlignment="Center" />
+                                            </Grid>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                            </StackPanel>
+                        </Border>
+
+                        <!--  Hidden-difficulty (map4) settings; only when the chart has a Hidden map  -->
+                        <Border
+                            Classes="Card"
+                            IsVisible="{Binding HasHiddenDifficulty}">
+                            <StackPanel
+                                Spacing="16">
+                                <TextBlock
+                                    Classes="SectionTitle"
+                                    Text="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Section_HiddenMode}}" />
+                                <StackPanel
+                                    Classes="Field">
+                                    <TextBlock
+                                        Classes="FieldLabel"
+                                        Text="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Field_HideMode}}" />
+                                    <TextBox
+                                        Text="{Binding HideMode}" />
+                                </StackPanel>
+                                <StackPanel
+                                    Classes="Field">
+                                    <TextBlock
+                                        Classes="FieldLabel"
+                                        Text="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Field_HideRatingOverride}}" />
+                                    <TextBox
+                                        Text="{Binding HideRatingOverride}" />
+                                </StackPanel>
+                                <StackPanel
+                                    Classes="Field">
+                                    <TextBlock
+                                        Classes="FieldLabel"
+                                        Text="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Field_HideMessage}}" />
+                                    <TextBox
+                                        Text="{Binding HideMessage}" />
+                                </StackPanel>
+                            </StackPanel>
+                        </Border>
+                    </StackPanel>
+                </Grid>
 
             </StackPanel>
         </ScrollViewer>
@@ -405,7 +554,7 @@
                     <TextBlock
                         Foreground="{DynamicResource SemiColorText2}"
                         IsVisible="{Binding !BpmRangeInvalid}"
-                        Text="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Hint_NameAuthorRequired}}"
+                        Text="{Localize {x:Static loc:XAMLLiteral.EpkEditor_Hint_Required}}"
                         VerticalAlignment="Center" />
                 </StackPanel>
                 <Button

--- a/src/Euterpe/Features/Charting/EpkEditorPanelViewModel.cs
+++ b/src/Euterpe/Features/Charting/EpkEditorPanelViewModel.cs
@@ -302,8 +302,8 @@ public sealed partial class EpkEditorPanelViewModel : ViewModelBase
         }
     }
 
-    // Map rows follow the union of the manifest's maps and the .bms files present in the folder, so a
-    // chart can be edited after a difficulty is dropped in or removed. Refresh keeps any in-flight edits.
+    // Rows track the .bms files on disk; the manifest only prefills each row's rating and charters, so a
+    // difficulty dropped into or removed from the folder appears or drops out on refresh. Edits are kept.
     private void ReconcileMaps(bool preserveEdits)
     {
         var kept = preserveEdits
@@ -318,14 +318,9 @@ public sealed partial class EpkEditorPanelViewModel : ViewModelBase
 
         Maps.Clear();
         var manifestMaps = _original?.Meta.Maps;
-        foreach (var difficulty in ChartDifficultyExtensions.GetValues())
+        foreach (var difficulty in _files.ExistingDifficulties())
         {
             var manifestMap = manifestMaps?.GetValueOrDefault(ChartFiles.MapName(difficulty));
-            if (manifestMap is null && !_files.ContainsKey(ChartFiles.MapFileName(difficulty)))
-            {
-                continue;
-            }
-
             var row = kept.GetValueOrDefault(difficulty)
                 ?? new DifficultyEditViewModel(difficulty, manifestMap?.Rating ?? string.Empty, manifestMap?.Charters ?? []);
             row.PropertyChanged += OnMapChanged;

--- a/src/Euterpe/Features/Charting/EpkEditorPanelViewModel.cs
+++ b/src/Euterpe/Features/Charting/EpkEditorPanelViewModel.cs
@@ -8,7 +8,6 @@ namespace Euterpe.Features.Charting;
 public sealed partial class EpkEditorPanelViewModel : ViewModelBase
 {
     private bool _loading;
-    private bool _dirty;
     private string? _filePath;
     private string? _folder;
     private Manifest? _original;
@@ -36,6 +35,8 @@ public sealed partial class EpkEditorPanelViewModel : ViewModelBase
     public partial bool SafeForStreamer { get; set; }
 
     [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(SaveCommand))]
+    [NotifyPropertyChangedFor(nameof(CanSave))]
     public partial int? Bpm { get; set; }
 
     [ObservableProperty]
@@ -57,6 +58,8 @@ public sealed partial class EpkEditorPanelViewModel : ViewModelBase
     public partial int? BpmMax { get; set; }
 
     [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(SaveCommand))]
+    [NotifyPropertyChangedFor(nameof(CanSave))]
     public partial string Scene { get; set; } = string.Empty;
 
     [ObservableProperty]
@@ -78,6 +81,9 @@ public sealed partial class EpkEditorPanelViewModel : ViewModelBase
     public partial string? HideMessage { get; set; }
 
     [ObservableProperty]
+    public partial string? FilePath { get; set; }
+
+    [ObservableProperty]
     public partial string? FolderPath { get; set; }
 
     [ObservableProperty]
@@ -97,6 +103,9 @@ public sealed partial class EpkEditorPanelViewModel : ViewModelBase
     [ObservableProperty]
     public partial string FilesSummary { get; set; } = string.Empty;
 
+    [ObservableProperty]
+    public partial bool IsDirty { get; set; }
+
     public ObservableCollection<string> SearchKeywords { get; } = [];
 
     public ObservableCollection<DifficultyEditViewModel> Maps { get; } = [];
@@ -106,7 +115,11 @@ public sealed partial class EpkEditorPanelViewModel : ViewModelBase
     public bool CanSave =>
         !Name.IsNullOrWhiteSpace()
         && !Author.IsNullOrWhiteSpace()
-        && !BpmRangeInvalid;
+        && !Scene.IsNullOrWhiteSpace()
+        && Bpm is not null
+        && !BpmRangeInvalid
+        && Maps.Any(static map => map.Difficulty == ChartDifficulty.Hard)
+        && Maps.All(static map => !map.Rating.IsNullOrWhiteSpace() && map.Charters.Any(static charter => !charter.IsNullOrWhiteSpace()));
 
     public bool BpmRangeInvalid =>
         IsBpmRange && (BpmMin is not { } min || BpmMax is not { } max || min > max);
@@ -144,20 +157,19 @@ public sealed partial class EpkEditorPanelViewModel : ViewModelBase
         HideRatingOverride = meta.HideRatingOverride;
         HideMessage = meta.HideMessage;
 
+        FilePath = filePath;
         FolderPath = _folder;
         CoverDominantColor = meta.CoverDominantColor;
         CoverPath = ResolveCoverPath();
 
         LoadKeywords(meta.SearchKeywords);
-        LoadMaps(meta.Maps);
-
-        HasHiddenDifficulty = meta.Maps.ContainsKey(ChartFiles.MapName(ChartDifficulty.Hidden));
+        ReconcileMaps(preserveEdits: false);
 
         RebuildFilesDisplay();
         RecomputeMissingFiles();
 
         _loading = false;
-        _dirty = false;
+        IsDirty = false;
     }
 
     [RelayCommand(CanExecute = nameof(CanSave))]
@@ -171,14 +183,12 @@ public sealed partial class EpkEditorPanelViewModel : ViewModelBase
         var bytes = MessagePackSerialization.SerializeManifest(BuildManifest());
         if (await FileSystemService.TryWriteFileAtomicAsync(_filePath, bytes).ConfigureAwait(true))
         {
-            _dirty = false;
+            IsDirty = false;
             NotificationService.SuccessLight(Notification_Content_Epk_Save_Success, Name);
             if (_folder is { } folder)
             {
                 Saved?.Invoke(folder);
             }
-
-            CloseRequested?.Invoke();
         }
         else
         {
@@ -189,7 +199,7 @@ public sealed partial class EpkEditorPanelViewModel : ViewModelBase
     [RelayCommand]
     private async Task BackAsync()
     {
-        if (_dirty &&
+        if (IsDirty &&
             await MessageBoxService.WarningConfirmAsync(MessageBox_Content_Epk_Discard_Confirm).ConfigureAwait(true) is not MessageBoxResult.Yes)
         {
             return;
@@ -221,8 +231,9 @@ public sealed partial class EpkEditorPanelViewModel : ViewModelBase
 
         _files = refreshed;
         RebuildFilesDisplay();
+        ReconcileMaps(preserveEdits: true);
         RecomputeMissingFiles();
-        _dirty = true;
+        IsDirty = true;
     }
 
     private Manifest BuildManifest()
@@ -230,15 +241,15 @@ public sealed partial class EpkEditorPanelViewModel : ViewModelBase
         var original = _original!;
         var meta = original.Meta;
 
-        var maps = new Dictionary<string, ManifestMap>(meta.Maps.Count, StringComparer.OrdinalIgnoreCase);
-        foreach (var (key, map) in meta.Maps)
+        var maps = new Dictionary<string, ManifestMap>(Maps.Count, StringComparer.OrdinalIgnoreCase);
+        foreach (var row in Maps)
         {
-            var edited = Maps.FirstOrDefault(row => string.Equals(ChartFiles.MapName(row.Difficulty), key, StringComparison.OrdinalIgnoreCase));
+            var key = ChartFiles.MapName(row.Difficulty);
             maps[key] = new ManifestMap
             {
-                Rating = edited?.Rating ?? map.Rating,
-                Charters = edited is not null ? CleanTags(edited.Charters) : map.Charters,
-                PredictedRating = map.PredictedRating
+                Rating = row.Rating,
+                Charters = CleanTags(row.Charters),
+                PredictedRating = meta.Maps.TryGetValue(key, out var originalMap) ? originalMap.PredictedRating : null
             };
         }
 
@@ -291,8 +302,14 @@ public sealed partial class EpkEditorPanelViewModel : ViewModelBase
         }
     }
 
-    private void LoadMaps(IReadOnlyDictionary<string, ManifestMap> mapsByName)
+    // Map rows follow the union of the manifest's maps and the .bms files present in the folder, so a
+    // chart can be edited after a difficulty is dropped in or removed. Refresh keeps any in-flight edits.
+    private void ReconcileMaps(bool preserveEdits)
     {
+        var kept = preserveEdits
+            ? Maps.ToDictionary(static row => row.Difficulty)
+            : new Dictionary<ChartDifficulty, DifficultyEditViewModel>();
+
         foreach (var row in Maps)
         {
             row.PropertyChanged -= OnMapChanged;
@@ -300,18 +317,24 @@ public sealed partial class EpkEditorPanelViewModel : ViewModelBase
         }
 
         Maps.Clear();
+        var manifestMaps = _original?.Meta.Maps;
         foreach (var difficulty in ChartDifficultyExtensions.GetValues())
         {
-            if (!mapsByName.TryGetValue(ChartFiles.MapName(difficulty), out var map))
+            var manifestMap = manifestMaps?.GetValueOrDefault(ChartFiles.MapName(difficulty));
+            if (manifestMap is null && !_files.ContainsKey(ChartFiles.MapFileName(difficulty)))
             {
                 continue;
             }
 
-            var row = new DifficultyEditViewModel(difficulty, map.Rating, map.Charters);
+            var row = kept.GetValueOrDefault(difficulty)
+                ?? new DifficultyEditViewModel(difficulty, manifestMap?.Rating ?? string.Empty, manifestMap?.Charters ?? []);
             row.PropertyChanged += OnMapChanged;
             row.Charters.CollectionChanged += OnEditCollectionChanged;
             Maps.Add(row);
         }
+
+        HasHiddenDifficulty = Maps.Any(static row => row.Difficulty == ChartDifficulty.Hidden);
+        NotifySaveCanExecuteChanged();
     }
 
     private string? ResolveCoverPath()
@@ -357,24 +380,34 @@ public sealed partial class EpkEditorPanelViewModel : ViewModelBase
     {
         if (!_loading)
         {
-            _dirty = true;
+            IsDirty = true;
         }
+
+        NotifySaveCanExecuteChanged();
     }
 
     private void OnEditCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
         if (!_loading)
         {
-            _dirty = true;
+            IsDirty = true;
         }
+
+        NotifySaveCanExecuteChanged();
+    }
+
+    private void NotifySaveCanExecuteChanged()
+    {
+        OnPropertyChanged(nameof(CanSave));
+        SaveCommand.NotifyCanExecuteChanged();
     }
 
     protected override void OnPropertyChanged(PropertyChangedEventArgs e)
     {
         base.OnPropertyChanged(e);
-        if (!_loading)
+        if (!_loading && e.PropertyName != nameof(IsDirty))
         {
-            _dirty = true;
+            IsDirty = true;
         }
     }
 

--- a/tests/Euterpe.Tests/App/ViewModels/EpkEditorPanelViewModelTest.cs
+++ b/tests/Euterpe.Tests/App/ViewModels/EpkEditorPanelViewModelTest.cs
@@ -83,6 +83,89 @@ public sealed class EpkEditorPanelViewModelTest
         await Assert.That(savedFolder).IsEqualTo(Path.GetDirectoryName("C:/charts/A/manifest.epk"));
     }
 
+    [Test]
+    public async Task RefreshFiles_WhenABmsAppears_AddsAnEditableMapRowAndKeepsEdits()
+    {
+        var folder = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["map1.bms"] = 1,
+            ["music.ogg"] = 1
+        };
+        var fileSystem = IFileSystemService.Mock();
+        fileSystem.GetFileSizes(Any<string>()).Returns(folder);
+
+        var vm = new EpkEditorPanelViewModel
+        {
+            Launcher = IPlatformLauncher.Mock(),
+            FileSystemService = fileSystem,
+            MessageBoxService = IMessageBoxService.Mock(),
+            MessagePackSerialization = IMessagePackSerializationService.Mock(),
+            NotificationService = INotificationService.Mock()
+        };
+        vm.Open("C:/charts/A/manifest.epk", EasyOnlyChart());
+        vm.Maps[0].Rating = "5";
+
+        await Assert.That(vm.Maps.Count).IsEqualTo(1);
+        await Assert.That(vm.HasHiddenDifficulty).IsFalse();
+
+        folder["map4.bms"] = 1;
+        vm.RefreshFilesCommand.Execute(null);
+
+        using var _ = Assert.Multiple();
+        await Assert.That(vm.Maps.Count).IsEqualTo(2);
+        await Assert.That(vm.Maps[0].Difficulty).IsEqualTo(ChartDifficulty.Easy);
+        await Assert.That(vm.Maps[0].Rating).IsEqualTo("5");
+        await Assert.That(vm.Maps[^1].Difficulty).IsEqualTo(ChartDifficulty.Hidden);
+        await Assert.That(vm.Maps[^1].Rating).IsEqualTo(string.Empty);
+        await Assert.That(vm.HasHiddenDifficulty).IsTrue();
+    }
+
+    [Test]
+    public async Task CanSave_RequiresSceneAndEveryPresentMapFilled()
+    {
+        var vm = NewViewModel();
+        vm.Open("C:/charts/A/manifest.epk", SingleChartWithoutHidden());
+
+        await Assert.That(vm.CanSave).IsTrue();
+
+        vm.Scene = "   ";
+        await Assert.That(vm.CanSave).IsFalse();
+        vm.Scene = "scene_01";
+        await Assert.That(vm.CanSave).IsTrue();
+
+        vm.Maps[1].Charters.Clear();
+        await Assert.That(vm.CanSave).IsFalse();
+    }
+
+    [Test]
+    public async Task CanSave_RequiresAMap2()
+    {
+        var vm = NewViewModel();
+        vm.Open("C:/charts/A/manifest.epk", EasyOnlyChart());
+
+        await Assert.That(vm.CanSave).IsFalse();
+    }
+
+    private static Manifest EasyOnlyChart() => new()
+    {
+        Schema = Manifest.CurrentSchema,
+        Meta = new ManifestMeta
+        {
+            Name = "Solo",
+            Author = "Author",
+            Scene = "scene",
+            Maps = new Dictionary<string, ManifestMap>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["map1"] = new() { Rating = "3", Charters = ["alice"] }
+            }
+        },
+        Files = new Dictionary<string, ManifestFileEntry>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["map1.bms"] = new() { Version = 1, Size = 10 },
+            ["music.ogg"] = new() { Version = 1, Size = 20 }
+        }
+    };
+
     private static EpkEditorPanelViewModel NewViewModel()
     {
         var fileSystem = IFileSystemService.Mock();

--- a/tests/Euterpe.Tests/App/ViewModels/EpkEditorPanelViewModelTest.cs
+++ b/tests/Euterpe.Tests/App/ViewModels/EpkEditorPanelViewModelTest.cs
@@ -37,7 +37,7 @@ public sealed class EpkEditorPanelViewModelTest
         await Assert.That(vm.Maps[0].Rating).IsEqualTo("3");
         await Assert.That(vm.Maps[0].Charters.Count).IsEqualTo(1);
         await Assert.That(vm.Maps[0].Charters[0]).IsEqualTo("alice");
-        await Assert.That(vm.Files.Count).IsEqualTo(2);
+        await Assert.That(vm.Files.Count).IsEqualTo(3);
     }
 
     [Test]
@@ -118,6 +118,40 @@ public sealed class EpkEditorPanelViewModelTest
         await Assert.That(vm.Maps[^1].Difficulty).IsEqualTo(ChartDifficulty.Hidden);
         await Assert.That(vm.Maps[^1].Rating).IsEqualTo(string.Empty);
         await Assert.That(vm.HasHiddenDifficulty).IsTrue();
+    }
+
+    [Test]
+    public async Task RefreshFiles_WhenABmsIsRemoved_DropsTheMapRowAndBlocksSave()
+    {
+        var folder = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["map1.bms"] = 1,
+            ["map2.bms"] = 1,
+            ["music.ogg"] = 1
+        };
+        var fileSystem = IFileSystemService.Mock();
+        fileSystem.GetFileSizes(Any<string>()).Returns(folder);
+
+        var vm = new EpkEditorPanelViewModel
+        {
+            Launcher = IPlatformLauncher.Mock(),
+            FileSystemService = fileSystem,
+            MessageBoxService = IMessageBoxService.Mock(),
+            MessagePackSerialization = IMessagePackSerializationService.Mock(),
+            NotificationService = INotificationService.Mock()
+        };
+        vm.Open("C:/charts/A/manifest.epk", SingleChartWithoutHidden());
+
+        await Assert.That(vm.Maps.Count).IsEqualTo(2);
+        await Assert.That(vm.CanSave).IsTrue();
+
+        folder.Remove("map2.bms");
+        vm.RefreshFilesCommand.Execute(null);
+
+        using var _ = Assert.Multiple();
+        await Assert.That(vm.Maps.Count).IsEqualTo(1);
+        await Assert.That(vm.Maps[0].Difficulty).IsEqualTo(ChartDifficulty.Easy);
+        await Assert.That(vm.CanSave).IsFalse();
     }
 
     [Test]
@@ -207,6 +241,7 @@ public sealed class EpkEditorPanelViewModelTest
         Files = new Dictionary<string, ManifestFileEntry>(StringComparer.OrdinalIgnoreCase)
         {
             ["map1.bms"] = new() { Version = 1, Size = 10 },
+            ["map2.bms"] = new() { Version = 1, Size = 30 },
             ["music.ogg"] = new() { Version = 1, Size = 20 }
         }
     };


### PR DESCRIPTION
Reworks the EPK metadata editor and the charter toolkit landing. No backend or serialization changes — the manifest model and all file I/O are untouched.

## Editor
- Dense, responsive two-column card layout (was a cramped single column), matching the app's other pages.
- Sections + terms aligned to the product vocabulary: Basic Info / Chart Info / Description & Discovery / Maps; Song Author (曲师), Rating (定数), Maps (地图), …
- Multi-line Description, aligned per-map rows, an unsaved-changes dot, Ctrl+S, and staying open after save.

## Maps
- Folder-driven: the editable difficulties are the union of the manifest's maps and the .bms files actually present, so a difficulty dropped into the folder appears (after Refresh) and a removed one drops out; saving writes every present map back.
- Required-field validation: name, author, scene, BPM, the presence of a Hard (map2), and a rating + charter for every present map.

## Toolkit
- New EPK: builds a blank manifest from a folder of assets.
- Reorganised into Offline tools (New / Open EPK) and Online tools (Chart Analyzer, Submit Chart — both open the Euterpe site).

## Localisation
- Updated across all 14 locales.

## Testing
- Release build clean; full suite green (Euterpe.Tests 631, Euterpe.Headless.Tests 118, Euterpe.Generators.Tests 14).