### PR TITLE
show a mod's incompatible mods on the detail page

### DIFF
--- a/src/Euterpe.Localization/XAML/XAML.de.resx
+++ b/src/Euterpe.Localization/XAML/XAML.de.resx
@@ -445,6 +445,9 @@
   <data name="ModInfo_Details" xml:space="preserve">
     <value>Details</value>
   </data>
+  <data name="ModInfo_IncompatibleMods" xml:space="preserve">
+    <value>Inkompatible Mods</value>
+  </data>
   <data name="ModInfo_Repository" xml:space="preserve">
     <value>Repository</value>
   </data>

--- a/src/Euterpe.Localization/XAML/XAML.es.resx
+++ b/src/Euterpe.Localization/XAML/XAML.es.resx
@@ -445,6 +445,9 @@
   <data name="ModInfo_Details" xml:space="preserve">
     <value>Detalles</value>
   </data>
+  <data name="ModInfo_IncompatibleMods" xml:space="preserve">
+    <value>Mods incompatibles</value>
+  </data>
   <data name="ModInfo_Repository" xml:space="preserve">
     <value>Repositorio</value>
   </data>

--- a/src/Euterpe.Localization/XAML/XAML.fr.resx
+++ b/src/Euterpe.Localization/XAML/XAML.fr.resx
@@ -445,6 +445,9 @@
   <data name="ModInfo_Details" xml:space="preserve">
     <value>Détails</value>
   </data>
+  <data name="ModInfo_IncompatibleMods" xml:space="preserve">
+    <value>Mods incompatibles</value>
+  </data>
   <data name="ModInfo_Repository" xml:space="preserve">
     <value>Dépôt</value>
   </data>

--- a/src/Euterpe.Localization/XAML/XAML.hr.resx
+++ b/src/Euterpe.Localization/XAML/XAML.hr.resx
@@ -445,6 +445,9 @@
   <data name="ModInfo_Details" xml:space="preserve">
     <value>Detalji</value>
   </data>
+  <data name="ModInfo_IncompatibleMods" xml:space="preserve">
+    <value>Nekompatibilni modovi</value>
+  </data>
   <data name="ModInfo_Repository" xml:space="preserve">
     <value>Repozitorij</value>
   </data>

--- a/src/Euterpe.Localization/XAML/XAML.hu.resx
+++ b/src/Euterpe.Localization/XAML/XAML.hu.resx
@@ -445,6 +445,9 @@
   <data name="ModInfo_Details" xml:space="preserve">
     <value>Részletek</value>
   </data>
+  <data name="ModInfo_IncompatibleMods" xml:space="preserve">
+    <value>Nem kompatibilis modok</value>
+  </data>
   <data name="ModInfo_Repository" xml:space="preserve">
     <value>Tároló</value>
   </data>

--- a/src/Euterpe.Localization/XAML/XAML.id.resx
+++ b/src/Euterpe.Localization/XAML/XAML.id.resx
@@ -445,6 +445,9 @@
   <data name="ModInfo_Details" xml:space="preserve">
     <value>Detail</value>
   </data>
+  <data name="ModInfo_IncompatibleMods" xml:space="preserve">
+    <value>Mod Tidak Kompatibel</value>
+  </data>
   <data name="ModInfo_Repository" xml:space="preserve">
     <value>Repositori</value>
   </data>

--- a/src/Euterpe.Localization/XAML/XAML.ja.resx
+++ b/src/Euterpe.Localization/XAML/XAML.ja.resx
@@ -445,6 +445,9 @@
   <data name="ModInfo_Details" xml:space="preserve">
     <value>詳細</value>
   </data>
+  <data name="ModInfo_IncompatibleMods" xml:space="preserve">
+    <value>非互換のMod</value>
+  </data>
   <data name="ModInfo_Repository" xml:space="preserve">
     <value>リポジトリ</value>
   </data>

--- a/src/Euterpe.Localization/XAML/XAML.ko.resx
+++ b/src/Euterpe.Localization/XAML/XAML.ko.resx
@@ -445,6 +445,9 @@
   <data name="ModInfo_Details" xml:space="preserve">
     <value>상세 정보</value>
   </data>
+  <data name="ModInfo_IncompatibleMods" xml:space="preserve">
+    <value>호환되지 않는 모드</value>
+  </data>
   <data name="ModInfo_Repository" xml:space="preserve">
     <value>저장소</value>
   </data>

--- a/src/Euterpe.Localization/XAML/XAML.nl.resx
+++ b/src/Euterpe.Localization/XAML/XAML.nl.resx
@@ -445,6 +445,9 @@
   <data name="ModInfo_Details" xml:space="preserve">
     <value>Details</value>
   </data>
+  <data name="ModInfo_IncompatibleMods" xml:space="preserve">
+    <value>Incompatibele mods</value>
+  </data>
   <data name="ModInfo_Repository" xml:space="preserve">
     <value>Repository</value>
   </data>

--- a/src/Euterpe.Localization/XAML/XAML.pt.resx
+++ b/src/Euterpe.Localization/XAML/XAML.pt.resx
@@ -445,6 +445,9 @@
   <data name="ModInfo_Details" xml:space="preserve">
     <value>Detalhes</value>
   </data>
+  <data name="ModInfo_IncompatibleMods" xml:space="preserve">
+    <value>Mods incompatíveis</value>
+  </data>
   <data name="ModInfo_Repository" xml:space="preserve">
     <value>Repositório</value>
   </data>

--- a/src/Euterpe.Localization/XAML/XAML.resx
+++ b/src/Euterpe.Localization/XAML/XAML.resx
@@ -451,6 +451,9 @@
   <data name="ModInfo_Details" xml:space="preserve">
     <value>Details</value>
   </data>
+  <data name="ModInfo_IncompatibleMods" xml:space="preserve">
+    <value>Incompatible Mods</value>
+  </data>
   <data name="ModInfo_Repository" xml:space="preserve">
     <value>Repository</value>
   </data>

--- a/src/Euterpe.Localization/XAML/XAML.ru.resx
+++ b/src/Euterpe.Localization/XAML/XAML.ru.resx
@@ -445,6 +445,9 @@
   <data name="ModInfo_Details" xml:space="preserve">
     <value>Подробности</value>
   </data>
+  <data name="ModInfo_IncompatibleMods" xml:space="preserve">
+    <value>Несовместимые моды</value>
+  </data>
   <data name="ModInfo_Repository" xml:space="preserve">
     <value>Репозиторий</value>
   </data>

--- a/src/Euterpe.Localization/XAML/XAML.zh-Hans.resx
+++ b/src/Euterpe.Localization/XAML/XAML.zh-Hans.resx
@@ -451,6 +451,9 @@
   <data name="ModInfo_Details" xml:space="preserve">
     <value>详情</value>
   </data>
+  <data name="ModInfo_IncompatibleMods" xml:space="preserve">
+    <value>不兼容的模组</value>
+  </data>
   <data name="ModInfo_Repository" xml:space="preserve">
     <value>仓库</value>
   </data>

--- a/src/Euterpe.Localization/XAML/XAML.zh-Hant.resx
+++ b/src/Euterpe.Localization/XAML/XAML.zh-Hant.resx
@@ -451,6 +451,9 @@
   <data name="ModInfo_Details" xml:space="preserve">
     <value>詳細資訊</value>
   </data>
+  <data name="ModInfo_IncompatibleMods" xml:space="preserve">
+    <value>不相容的模組</value>
+  </data>
   <data name="ModInfo_Repository" xml:space="preserve">
     <value>儲存庫</value>
   </data>

--- a/src/Euterpe.Models/Mods/ModDto.cs
+++ b/src/Euterpe.Models/Mods/ModDto.cs
@@ -65,7 +65,7 @@ public sealed partial class ModDto : ObservableObject
     public bool HasRepository => !Repository.IsNullOrEmpty();
 
     // Screenshots
-    public bool HasScreenshots => Screenshots.Length > 0;
+    public bool HasScreenshots => Screenshots is not [];
 
     // Dependencies
     public bool HasDependency => ModDependencies.Length + LibDependencies.Length > 0;

--- a/src/Euterpe.Models/Mods/ModDto.cs
+++ b/src/Euterpe.Models/Mods/ModDto.cs
@@ -72,6 +72,9 @@ public sealed partial class ModDto : ObservableObject
 
     public string[] DependencyNames => !HasDependency ? [] : [.. ModDependencies, .. LibDependencies];
 
+    // Incompatible mods
+    public bool HasIncompatibleMods => IncompatibleMods is not [];
+
     // LocalizedStrings
     public LocalizedString LocalizedCompatibleGameVersion => GameVersion is "*" ? AllGameVersionCompatible : GameVersion;
 

--- a/src/Euterpe/Features/Modding/ModManagePanel.axaml
+++ b/src/Euterpe/Features/Modding/ModManagePanel.axaml
@@ -519,6 +519,31 @@
                         </ItemsControl>
                     </StackPanel>
 
+                    <!--  Incompatible Mods Section: mods that can't be used alongside this one  -->
+                    <StackPanel
+                        IsVisible="{Binding SelectedMod.HasIncompatibleMods, Mode=OneWay}">
+                        <TextBlock
+                            Classes="SectionTitle"
+                            Text="{Localize {x:Static loc:XAMLLiteral.ModInfo_IncompatibleMods}}" />
+                        <ItemsControl
+                            ItemsSource="{Binding SelectedMod.IncompatibleMods, Mode=OneWay}">
+                            <ItemsControl.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <WrapPanel
+                                        Orientation="Horizontal" />
+                                </ItemsPanelTemplate>
+                            </ItemsControl.ItemsPanel>
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <Label
+                                        Classes="Ghost Gray TagLabel"
+                                        Content="{Binding ., Mode=OneWay}"
+                                        Margin="0,0,8,8" />
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </StackPanel>
+
                 </StackPanel>
             </ScrollViewer>
         </Panel>


### PR DESCRIPTION
Surfaces a mod''s incompatible mods on the mod detail page.

The detail already lists **Dependencies** but never showed `IncompatibleMods` — the field was already on `ModDto`, just unused in the view. This adds an **Incompatible Mods** section under Dependencies: a plain heading plus the conflicting mod names as neutral grey tags that wrap horizontally. It is informational status, not a warning, so no red/alert styling.

Visibility is gated on a `HasIncompatibleMods` computed property, mirroring the existing `HasDependency` / `HasScreenshots` on `ModDto`.

Localised across all 14 locales (matching each file''s existing "Mod" / "Incompatible" rendering).

Build clean.