### PR TITLE
feat: per-file chart-sync diff for check-updates

### DIFF
--- a/src/Euterpe.Abstractions/DownloadManager/IGameDownloadManager.cs
+++ b/src/Euterpe.Abstractions/DownloadManager/IGameDownloadManager.cs
@@ -12,7 +12,7 @@ public interface IGameDownloadManager
 
     // Chart operations
     Task<string> DownloadChartAsync(string cid, IProgress<BatchProgress>? progress = null, CancellationToken cancellationToken = default);
-    Task<string> UpdateChartAsync(string cid, IReadOnlyCollection<string> changedFiles, CancellationToken cancellationToken = default);
+    Task<string> UpdateChartAsync(string cid, IReadOnlyCollection<string> changedFiles, IReadOnlyCollection<string> deletedFiles, CancellationToken cancellationToken = default);
     Task<CheckChartUpdatesResponse> CheckChartUpdatesAsync(CheckChartUpdatesRequest request, CancellationToken cancellationToken = default);
 
     // Catalog fetches

--- a/src/Euterpe.Contracts/Charts/ChartUpdateDelta.cs
+++ b/src/Euterpe.Contracts/Charts/ChartUpdateDelta.cs
@@ -3,7 +3,6 @@ namespace Euterpe.Contracts.Charts;
 [PublicAPI]
 public sealed class ChartUpdateDelta
 {
-    public List<string> Changed { get; set; } = [];
-
-    public List<string> Deleted { get; set; } = [];
+    public string[] Changed { get; set; } = [];
+    public string[] Deleted { get; set; } = [];
 }

--- a/src/Euterpe.Contracts/Charts/ChartUpdateDelta.cs
+++ b/src/Euterpe.Contracts/Charts/ChartUpdateDelta.cs
@@ -1,0 +1,9 @@
+namespace Euterpe.Contracts.Charts;
+
+[PublicAPI]
+public sealed class ChartUpdateDelta
+{
+    public List<string> Changed { get; set; } = [];
+
+    public List<string> Deleted { get; set; } = [];
+}

--- a/src/Euterpe.Contracts/Charts/CheckChartUpdatesResponse.cs
+++ b/src/Euterpe.Contracts/Charts/CheckChartUpdatesResponse.cs
@@ -3,7 +3,5 @@ namespace Euterpe.Contracts.Charts;
 [PublicAPI]
 public sealed class CheckChartUpdatesResponse
 {
-    public Dictionary<string, Dictionary<string, ChartFileEntry>> Updates { get; set; } = [];
-
-    public int[] Removed { get; set; } = [];
+    public Dictionary<string, ChartUpdateDelta> Charts { get; set; } = [];
 }

--- a/src/Euterpe.Core/Services/ChartManageService/ChartManageService.Core.cs
+++ b/src/Euterpe.Core/Services/ChartManageService/ChartManageService.Core.cs
@@ -35,11 +35,11 @@ internal sealed partial class ChartManageService
         }
     }
 
-    private async Task<ChartUpdateResult> UpdateChartCoreAsync(string cid, IReadOnlyCollection<string> changedFiles, CancellationToken cancellationToken)
+    private async Task<ChartUpdateResult> UpdateChartCoreAsync(string cid, IReadOnlyCollection<string> changedFiles, IReadOnlyCollection<string> deletedFiles, CancellationToken cancellationToken)
     {
         try
         {
-            var folderPath = await GameDownloadManager.UpdateChartAsync(cid, changedFiles, cancellationToken).ConfigureAwait(false);
+            var folderPath = await GameDownloadManager.UpdateChartAsync(cid, changedFiles, deletedFiles, cancellationToken).ConfigureAwait(false);
 
             var chart = await ChartLocalService.LoadChartFromPathAsync(folderPath, ChartSource.Online).ConfigureAwait(false);
             if (chart is null)

--- a/src/Euterpe.Core/Services/ChartManageService/ChartManageService.Update.cs
+++ b/src/Euterpe.Core/Services/ChartManageService/ChartManageService.Update.cs
@@ -1,4 +1,5 @@
 using Euterpe.Contracts.Charts;
+using static Euterpe.Models.Charts.ChartFiles;
 
 namespace Euterpe.Core;
 
@@ -12,32 +13,38 @@ internal sealed partial class ChartManageService
             return results;
         }
 
-        var request = new CheckChartUpdatesRequest
-        {
-            Charts = charts.ToDictionary(
-                chart => chart.FolderName,
-                chart => chart.Manifest.Files.ToDictionary(
-                    file => file.Key,
-                    file => new ChartFileEntry
-                    {
-                        Version = file.Value.Version
-                    }))
-        };
+        // BuildFileVersions scans each chart folder (synchronous I/O); keep it off the calling UI thread.
+        var request = await Task.Run(
+                () => new CheckChartUpdatesRequest
+                {
+                    Charts = charts.ToDictionary(chart => chart.FolderName, BuildFileVersions)
+                },
+                cancellationToken)
+            .ConfigureAwait(false);
 
         var response = await GameDownloadManager.CheckChartUpdatesAsync(request, cancellationToken).ConfigureAwait(false);
 
-        foreach (var (cid, changedFiles) in response.Updates)
+        foreach (var (cid, delta) in response.Charts)
         {
-            string[] files = [.. changedFiles.Keys];
-            var result = await RunExclusiveAsync(cid, () => UpdateChartCoreAsync(cid, files, cancellationToken)).ConfigureAwait(false);
+            if (delta.Deleted.Contains(ManifestFileName))
+            {
+                await RunExclusiveAsync(cid, () => RemoveDelistedChartCoreAsync(cid)).ConfigureAwait(false);
+                continue;
+            }
+
+            var result = await RunExclusiveAsync(cid, () => UpdateChartCoreAsync(cid, delta.Changed, delta.Deleted, cancellationToken)).ConfigureAwait(false);
             results.Add(result);
         }
 
-        foreach (var cid in response.Removed)
-        {
-            await RunExclusiveAsync(cid.ToString(), () => RemoveDelistedChartCoreAsync(cid.ToString())).ConfigureAwait(false);
-        }
-
         return results;
+    }
+
+    // Report on-disk chart files, not just manifest entries, so the server's reverse diff prunes orphans the manifest no longer lists.
+    private Dictionary<string, ChartFileEntry> BuildFileVersions(ChartDto chart)
+    {
+        var declared = chart.Manifest.Files;
+        return FileSystemService.GetFileSizes(chart.FolderPath).Keys
+            .Where(fileName => declared.ContainsKey(fileName) || IsChartFile(fileName))
+            .ToDictionary(fileName => fileName, fileName => new ChartFileEntry { Version = declared.GetValueOrDefault(fileName)?.Version ?? 0 });
     }
 }

--- a/src/Euterpe.Core/Services/ChartManageService/ChartManageService.Update.cs
+++ b/src/Euterpe.Core/Services/ChartManageService/ChartManageService.Update.cs
@@ -13,7 +13,7 @@ internal sealed partial class ChartManageService
             return results;
         }
 
-        // BuildFileVersions scans each chart folder (synchronous I/O); keep it off the calling UI thread.
+        // Per-chart disk scan is synchronous; keep it off the UI thread.
         var request = await Task.Run(
                 () => new CheckChartUpdatesRequest
                 {
@@ -39,7 +39,7 @@ internal sealed partial class ChartManageService
         return results;
     }
 
-    // Report on-disk chart files, not just manifest entries, so the server's reverse diff prunes orphans the manifest no longer lists.
+    // Report on-disk orphans (version 0) too, so the server's reverse diff can prune them.
     private Dictionary<string, ChartFileEntry> BuildFileVersions(ChartDto chart)
     {
         var declared = chart.Manifest.Files;

--- a/src/Euterpe.Core/Services/DownloadManager/GameDownloadManager.cs
+++ b/src/Euterpe.Core/Services/DownloadManager/GameDownloadManager.cs
@@ -1,6 +1,7 @@
 using Euterpe.Contracts.Charts;
 using Euterpe.Contracts.Distribution;
 using Euterpe.Contracts.Mods;
+using static Euterpe.Models.Charts.ChartFiles;
 
 namespace Euterpe.Core;
 
@@ -39,9 +40,9 @@ internal sealed partial class GameDownloadManager : IGameDownloadManager
         }
     }
 
-    public async Task<string> UpdateChartAsync(string cid, IReadOnlyCollection<string> changedFiles, CancellationToken cancellationToken = default)
+    public async Task<string> UpdateChartAsync(string cid, IReadOnlyCollection<string> changedFiles, IReadOnlyCollection<string> deletedFiles, CancellationToken cancellationToken = default)
     {
-        Logger.ZLogInformation($"Updating chart {cid} ({changedFiles.Count} changed file(s)) ...");
+        Logger.ZLogInformation($"Updating chart {cid} ({changedFiles.Count} changed, {deletedFiles.Count} deleted file(s)) ...");
 
         var workFolder = Path.Combine(GameConfig.TempChartsFolder, cid);
         var destinationFolder = Path.Combine(GameConfig.OnlineChartsFolder, cid);
@@ -51,9 +52,18 @@ internal sealed partial class GameDownloadManager : IGameDownloadManager
             FileSystemService.TryDeleteDirectory(workFolder, DeleteOption.IgnoreIfNotFound);
             FileSystemService.CopyDirectory(destinationFolder, workFolder);
 
-            foreach (var fileName in changedFiles)
+            // Any change bumps the manifest, so refetch it whenever changedFiles is non-empty (the server omits it when other files change); a pure orphan cleanup downloads nothing.
+            var toDownload = changedFiles.Count > 0
+                ? changedFiles.Append(ManifestFileName).Distinct(StringComparer.Ordinal)
+                : changedFiles;
+            foreach (var fileName in toDownload)
             {
                 await DownloadChartFileAsync(cid, workFolder, fileName, cancellationToken).ConfigureAwait(false);
+            }
+
+            foreach (var fileName in deletedFiles)
+            {
+                FileSystemService.TryDeleteFile(Path.Combine(workFolder, fileName), DeleteOption.IgnoreIfNotFound);
             }
 
             if (!FileSystemService.TryMoveDirectory(workFolder, destinationFolder, true))

--- a/src/Euterpe.Core/Services/DownloadManager/GameDownloadManager.cs
+++ b/src/Euterpe.Core/Services/DownloadManager/GameDownloadManager.cs
@@ -52,9 +52,9 @@ internal sealed partial class GameDownloadManager : IGameDownloadManager
             FileSystemService.TryDeleteDirectory(workFolder, DeleteOption.IgnoreIfNotFound);
             FileSystemService.CopyDirectory(destinationFolder, workFolder);
 
-            // Any change bumps the manifest, so refetch it whenever changedFiles is non-empty (the server omits it when other files change); a pure orphan cleanup downloads nothing.
+            // The server omits manifest.epk when other files change; re-add it, since every change bumps it.
             var toDownload = changedFiles.Count > 0
-                ? changedFiles.Append(ManifestFileName).Distinct(StringComparer.Ordinal)
+                ? changedFiles.Append(ManifestFileName).Distinct(StringComparer.OrdinalIgnoreCase)
                 : changedFiles;
             foreach (var fileName in toDownload)
             {

--- a/src/Euterpe.Models/Charts/ChartFiles.cs
+++ b/src/Euterpe.Models/Charts/ChartFiles.cs
@@ -26,8 +26,7 @@ public static class ChartFiles
     public static bool IsCoverFile(string fileName) =>
         Path.GetFileNameWithoutExtension(fileName.AsSpan()).Equals(CoverName, StringComparison.OrdinalIgnoreCase);
 
-    // Every file name a chart may carry, including retired ones (e.g. legacy cover.png) so orphans of any
-    // type surface for the server's reverse diff to prune.
+    // Recognises retired names too (e.g. legacy cover.png) so the server's reverse diff can prune orphans.
     public static bool IsChartFile(string fileName) =>
         fileName is ManifestFileName or MusicFileName or DemoFileName or VideoFileName
         || IsCoverFile(fileName)

--- a/src/Euterpe.Models/Charts/ChartFiles.cs
+++ b/src/Euterpe.Models/Charts/ChartFiles.cs
@@ -15,14 +15,42 @@ public static class ChartFiles
     public const string DemoName = "demo";
     public const string MusicExtension = ".ogg";
 
+    public const string MapPrefix = "map";
+    public const string BmsExtension = ".bms";
+    public const string TalkExtension = ".talk";
+
     public static readonly IReadOnlyList<string> CoverExtensions = [".webp", ".png", ".gif"];
 
     public static bool IsLargeMedia(string fileName) => fileName == VideoFileName;
 
-    public static string MapName(ChartDifficulty difficulty) => $"map{(int)difficulty}";
+    public static bool IsCoverFile(string fileName) =>
+        Path.GetFileNameWithoutExtension(fileName.AsSpan()).Equals(CoverName, StringComparison.OrdinalIgnoreCase);
 
-    public static string MapFileName(ChartDifficulty difficulty) => $"map{(int)difficulty}.bms";
+    // Every file name a chart may carry, including retired ones (e.g. legacy cover.png) so orphans of any
+    // type surface for the server's reverse diff to prune.
+    public static bool IsChartFile(string fileName) =>
+        fileName is ManifestFileName or MusicFileName or DemoFileName or VideoFileName
+        || IsCoverFile(fileName)
+        || IsMapFile(fileName);
+
+    public static string MapName(ChartDifficulty difficulty) => $"{MapPrefix}{(int)difficulty}";
+
+    public static string MapFileName(ChartDifficulty difficulty) => $"{MapName(difficulty)}{BmsExtension}";
 
     public static IReadOnlyList<ChartDifficulty> ExistingDifficulties(this IReadOnlyDictionary<string, ManifestFileEntry> files) =>
         [.. ChartDifficultyExtensions.GetValues().Where(difficulty => files.ContainsKey(MapFileName(difficulty)))];
+
+    private static bool IsMapFile(string fileName)
+    {
+        var extension = Path.GetExtension(fileName.AsSpan());
+        if (!extension.Equals(BmsExtension, StringComparison.OrdinalIgnoreCase)
+            && !extension.Equals(TalkExtension, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var stem = Path.GetFileNameWithoutExtension(fileName.AsSpan());
+        return stem.StartsWith(MapPrefix, StringComparison.OrdinalIgnoreCase)
+            && int.TryParse(stem[MapPrefix.Length..], out _);
+    }
 }

--- a/tests/Euterpe.Tests/Core/Services/ChartManageService/ChartManageServiceTest.Reconcile.cs
+++ b/tests/Euterpe.Tests/Core/Services/ChartManageService/ChartManageServiceTest.Reconcile.cs
@@ -1,5 +1,4 @@
 using DynamicData;
-using Euterpe.Models.Charts.CustomAlbums;
 
 namespace Euterpe.Tests.Core;
 
@@ -8,13 +7,13 @@ public sealed partial class ChartManageServiceTest
     [Test]
     public async Task ReconcileChartsAsync_NewFolderOnDisk_AddsChart()
     {
-        var local = new MutableChartLocalService();
+        var local = new FakeChartLocalService();
         var service = CreateService(local);
         await service.InitializeChartsAsync();
         using var connection = service.Connect().Bind(out var charts).Subscribe();
         await Assert.That(charts.Count).IsEqualTo(0);
 
-        local.Set("/charts/A", ChartAt("/charts/A", "A"));
+        local.Set(CreateChart("A"));
         await service.ReconcileChartsAsync();
 
         using var _ = Assert.Multiple();
@@ -25,14 +24,14 @@ public sealed partial class ChartManageServiceTest
     [Test]
     public async Task ReconcileChartsAsync_FolderRemovedFromDisk_PrunesChart()
     {
-        var local = new MutableChartLocalService();
-        local.Set("/charts/A", ChartAt("/charts/A", "A"));
+        var local = new FakeChartLocalService();
+        local.Set(CreateChart("A"));
         var service = CreateService(local);
         await service.InitializeChartsAsync();
         using var connection = service.Connect().Bind(out var charts).Subscribe();
         await Assert.That(charts.Count).IsEqualTo(1);
 
-        local.Remove("/charts/A");
+        local.Remove(ChartFolder);
         await service.ReconcileChartsAsync();
 
         await Assert.That(charts.Count).IsEqualTo(0);
@@ -41,8 +40,8 @@ public sealed partial class ChartManageServiceTest
     [Test]
     public async Task ReconcileChartsAsync_UnchangedLibrary_DoesNotDuplicate()
     {
-        var local = new MutableChartLocalService();
-        local.Set("/charts/A", ChartAt("/charts/A", "A"));
+        var local = new FakeChartLocalService();
+        local.Set(CreateChart("A"));
         var service = CreateService(local);
         await service.InitializeChartsAsync();
         using var connection = service.Connect().Bind(out var charts).Subscribe();
@@ -50,38 +49,5 @@ public sealed partial class ChartManageServiceTest
         await service.ReconcileChartsAsync();
 
         await Assert.That(charts.Count).IsEqualTo(1);
-    }
-
-    private static ChartDto ChartAt(string folder, string name) =>
-        new()
-        {
-            FolderPath = folder,
-            FolderName = Path.GetFileName(folder),
-            Source = ChartSource.Offline,
-            Manifest = new Manifest
-            {
-                Schema = Manifest.CurrentSchema,
-                Meta = new ManifestMeta { Name = name, Author = "author", Scene = "scene", Maps = new() },
-                Files = new()
-            }
-        };
-
-    private sealed class MutableChartLocalService : IChartLocalService
-    {
-        private readonly Dictionary<string, ChartDto> _offline = [];
-
-        public void Set(string folder, ChartDto chart) => _offline[folder] = chart;
-
-        public void Remove(string folder) => _offline.Remove(folder);
-
-        public IEnumerable<string> GetChartFolderPaths(ChartSource source) =>
-            source is ChartSource.Offline ? _offline.Keys : [];
-
-        public Task<ChartDto?> LoadChartFromPathAsync(string chartFolder, ChartSource source) =>
-            Task.FromResult(_offline.GetValueOrDefault(chartFolder));
-
-        public CustomAlbumSource CreateCustomAlbumSource(string path) => throw new NotSupportedException();
-
-        public CustomAlbumSource[] GetCustomAlbumsSources() => throw new NotSupportedException();
     }
 }

--- a/tests/Euterpe.Tests/Core/Services/ChartManageService/ChartManageServiceTest.Update.cs
+++ b/tests/Euterpe.Tests/Core/Services/ChartManageService/ChartManageServiceTest.Update.cs
@@ -1,0 +1,102 @@
+using DynamicData;
+using Euterpe.Contracts.Charts;
+using Euterpe.Models.Charts.CustomAlbums;
+
+namespace Euterpe.Tests.Core;
+
+public sealed partial class ChartManageServiceTest
+{
+    [Test]
+    public async Task UpdateAllChartsAsync_ManifestInDeleted_PrunesTombstonedChart()
+    {
+        var local = new OnlineChartLocalService();
+        local.Set("/online/13", OnlineChartAt("/online/13", "Song"));
+
+        var fileSystem = IFileSystemService.Mock();
+        fileSystem.GetFileSizes(Any<string>()).Returns(new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase) { ["manifest.epk"] = 1 });
+        fileSystem.TryDeleteDirectory(Any<string>(), Any<DeleteOption>()).Returns(true);
+
+        var download = IGameDownloadManager.Mock();
+        download.CheckChartUpdatesAsync(Any<CheckChartUpdatesRequest>(), Any<CancellationToken>())
+            .Returns(new CheckChartUpdatesResponse
+            {
+                Charts = { ["13"] = new ChartUpdateDelta { Deleted = ["manifest.epk"] } }
+            });
+
+        var service = CreateService(local, download, fileSystem);
+        await service.InitializeChartsAsync();
+        using var _ = service.Connect().Bind(out var charts).Subscribe();
+        await Assert.That(charts.Count).IsEqualTo(1);
+
+        await service.UpdateAllChartsAsync();
+
+        await Assert.That(charts.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task UpdateAllChartsAsync_ChangedAndDeletedDelta_UpdatesThroughDownloadManager()
+    {
+        var local = new OnlineChartLocalService();
+        local.Set("/online/13", OnlineChartAt("/online/13", "before"));
+
+        var fileSystem = IFileSystemService.Mock();
+        fileSystem.GetFileSizes(Any<string>()).Returns(new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["manifest.epk"] = 1,
+            ["music.ogg"] = 2,
+            ["cover.png"] = 3
+        });
+
+        var download = IGameDownloadManager.Mock();
+        download.CheckChartUpdatesAsync(Any<CheckChartUpdatesRequest>(), Any<CancellationToken>())
+            .Returns(new CheckChartUpdatesResponse
+            {
+                Charts = { ["13"] = new ChartUpdateDelta { Changed = ["music.ogg"], Deleted = ["cover.png"] } }
+            });
+        download.UpdateChartAsync("13", Any<IReadOnlyCollection<string>>(), Any<IReadOnlyCollection<string>>(), Any<CancellationToken>())
+            .Returns("/online/13");
+
+        var service = CreateService(local, download, fileSystem);
+        await service.InitializeChartsAsync();
+        using var _ = service.Connect().Bind(out var charts).Subscribe();
+
+        local.Set("/online/13", OnlineChartAt("/online/13", "after"));
+        await service.UpdateAllChartsAsync();
+
+        using var __ = Assert.Multiple();
+        download.UpdateChartAsync("13", Any<IReadOnlyCollection<string>>(), Any<IReadOnlyCollection<string>>(), Any<CancellationToken>()).WasCalled(Times.Once);
+        await Assert.That(charts.Count).IsEqualTo(1);
+        await Assert.That(charts[0].Manifest.Meta.Name).IsEqualTo("after");
+    }
+
+    private static ChartDto OnlineChartAt(string folder, string name) =>
+        new()
+        {
+            FolderPath = folder,
+            FolderName = Path.GetFileName(folder),
+            Source = ChartSource.Online,
+            Manifest = new Manifest
+            {
+                Schema = Manifest.CurrentSchema,
+                Meta = new ManifestMeta { Name = name, Author = "author", Scene = "scene", Maps = new() },
+                Files = new()
+            }
+        };
+
+    private sealed class OnlineChartLocalService : IChartLocalService
+    {
+        private readonly Dictionary<string, ChartDto> _online = [];
+
+        public void Set(string folder, ChartDto chart) => _online[folder] = chart;
+
+        public IEnumerable<string> GetChartFolderPaths(ChartSource source) =>
+            source is ChartSource.Online ? _online.Keys : [];
+
+        public Task<ChartDto?> LoadChartFromPathAsync(string chartFolder, ChartSource source) =>
+            Task.FromResult(_online.GetValueOrDefault(chartFolder));
+
+        public CustomAlbumSource CreateCustomAlbumSource(string path) => throw new NotSupportedException();
+
+        public CustomAlbumSource[] GetCustomAlbumsSources() => throw new NotSupportedException();
+    }
+}

--- a/tests/Euterpe.Tests/Core/Services/ChartManageService/ChartManageServiceTest.Update.cs
+++ b/tests/Euterpe.Tests/Core/Services/ChartManageService/ChartManageServiceTest.Update.cs
@@ -1,6 +1,5 @@
 using DynamicData;
 using Euterpe.Contracts.Charts;
-using Euterpe.Models.Charts.CustomAlbums;
 
 namespace Euterpe.Tests.Core;
 
@@ -9,8 +8,8 @@ public sealed partial class ChartManageServiceTest
     [Test]
     public async Task UpdateAllChartsAsync_ManifestInDeleted_PrunesTombstonedChart()
     {
-        var local = new OnlineChartLocalService();
-        local.Set("/online/13", OnlineChartAt("/online/13", "Song"));
+        var local = new FakeChartLocalService();
+        local.Set(CreateChart("Song", ChartSource.Online, "/online/13"));
 
         var fileSystem = IFileSystemService.Mock();
         fileSystem.GetFileSizes(Any<string>()).Returns(new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase) { ["manifest.epk"] = 1 });
@@ -36,8 +35,8 @@ public sealed partial class ChartManageServiceTest
     [Test]
     public async Task UpdateAllChartsAsync_ChangedAndDeletedDelta_UpdatesThroughDownloadManager()
     {
-        var local = new OnlineChartLocalService();
-        local.Set("/online/13", OnlineChartAt("/online/13", "before"));
+        var local = new FakeChartLocalService();
+        local.Set(CreateChart("before", ChartSource.Online, "/online/13"));
 
         var fileSystem = IFileSystemService.Mock();
         fileSystem.GetFileSizes(Any<string>()).Returns(new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase)
@@ -60,43 +59,12 @@ public sealed partial class ChartManageServiceTest
         await service.InitializeChartsAsync();
         using var _ = service.Connect().Bind(out var charts).Subscribe();
 
-        local.Set("/online/13", OnlineChartAt("/online/13", "after"));
+        local.Set(CreateChart("after", ChartSource.Online, "/online/13"));
         await service.UpdateAllChartsAsync();
 
         using var __ = Assert.Multiple();
         download.UpdateChartAsync("13", Any<IReadOnlyCollection<string>>(), Any<IReadOnlyCollection<string>>(), Any<CancellationToken>()).WasCalled(Times.Once);
         await Assert.That(charts.Count).IsEqualTo(1);
         await Assert.That(charts[0].Manifest.Meta.Name).IsEqualTo("after");
-    }
-
-    private static ChartDto OnlineChartAt(string folder, string name) =>
-        new()
-        {
-            FolderPath = folder,
-            FolderName = Path.GetFileName(folder),
-            Source = ChartSource.Online,
-            Manifest = new Manifest
-            {
-                Schema = Manifest.CurrentSchema,
-                Meta = new ManifestMeta { Name = name, Author = "author", Scene = "scene", Maps = new() },
-                Files = new()
-            }
-        };
-
-    private sealed class OnlineChartLocalService : IChartLocalService
-    {
-        private readonly Dictionary<string, ChartDto> _online = [];
-
-        public void Set(string folder, ChartDto chart) => _online[folder] = chart;
-
-        public IEnumerable<string> GetChartFolderPaths(ChartSource source) =>
-            source is ChartSource.Online ? _online.Keys : [];
-
-        public Task<ChartDto?> LoadChartFromPathAsync(string chartFolder, ChartSource source) =>
-            Task.FromResult(_online.GetValueOrDefault(chartFolder));
-
-        public CustomAlbumSource CreateCustomAlbumSource(string path) => throw new NotSupportedException();
-
-        public CustomAlbumSource[] GetCustomAlbumsSources() => throw new NotSupportedException();
     }
 }

--- a/tests/Euterpe.Tests/Core/Services/ChartManageService/ChartManageServiceTest.cs
+++ b/tests/Euterpe.Tests/Core/Services/ChartManageService/ChartManageServiceTest.cs
@@ -13,12 +13,13 @@ public sealed partial class ChartManageServiceTest
     [Test]
     public async Task RefreshChartAsync_KnownFolder_ReloadsManifestFromDisk()
     {
-        var local = new FakeChartLocalService(ChartFolder) { Chart = CreateChart("before") };
+        var local = new FakeChartLocalService();
+        local.Set(CreateChart("before"));
         var service = CreateService(local);
         await service.InitializeChartsAsync();
         using var _ = service.Connect().Bind(out var charts).Subscribe();
 
-        local.Chart = CreateChart("after");
+        local.Set(CreateChart("after"));
         await service.RefreshChartAsync(ChartFolder);
 
         await Assert.That(charts[0].Manifest.Meta.Name).IsEqualTo("after");
@@ -27,12 +28,13 @@ public sealed partial class ChartManageServiceTest
     [Test]
     public async Task RefreshChartAsync_FolderOutsideLibrary_LeavesLibraryUnchanged()
     {
-        var local = new FakeChartLocalService(ChartFolder) { Chart = CreateChart("before") };
+        var local = new FakeChartLocalService();
+        local.Set(CreateChart("before"));
         var service = CreateService(local);
         await service.InitializeChartsAsync();
         using var _ = service.Connect().Bind(out var charts).Subscribe();
 
-        local.Chart = CreateChart("after");
+        local.Set(CreateChart("after"));
         await service.RefreshChartAsync("/somewhere/else");
 
         await Assert.That(charts.Count).IsEqualTo(1);
@@ -55,12 +57,12 @@ public sealed partial class ChartManageServiceTest
             MigrationService = IMigrationService.Mock()
         };
 
-    private static ChartDto CreateChart(string name) =>
+    private static ChartDto CreateChart(string name, ChartSource source = ChartSource.Offline, string folderPath = ChartFolder) =>
         new()
         {
-            FolderPath = ChartFolder,
-            FolderName = "A",
-            Source = ChartSource.Offline,
+            FolderPath = folderPath,
+            FolderName = Path.GetFileName(folderPath),
+            Source = source,
             Manifest = new Manifest
             {
                 Schema = Manifest.CurrentSchema,
@@ -69,15 +71,19 @@ public sealed partial class ChartManageServiceTest
             }
         };
 
-    private sealed class FakeChartLocalService(string offlineFolder) : IChartLocalService
+    private sealed class FakeChartLocalService : IChartLocalService
     {
-        public ChartDto? Chart { get; set; }
+        private readonly Dictionary<string, ChartDto> _charts = [];
+
+        public void Set(ChartDto chart) => _charts[chart.FolderPath] = chart;
+
+        public void Remove(string folderPath) => _charts.Remove(folderPath);
 
         public IEnumerable<string> GetChartFolderPaths(ChartSource source) =>
-            source is ChartSource.Offline ? [offlineFolder] : [];
+            _charts.Values.Where(chart => chart.Source == source).Select(chart => chart.FolderPath);
 
         public Task<ChartDto?> LoadChartFromPathAsync(string chartFolder, ChartSource source) =>
-            Task.FromResult(Chart);
+            Task.FromResult(_charts.GetValueOrDefault(chartFolder));
 
         public CustomAlbumSource CreateCustomAlbumSource(string path) => throw new NotSupportedException();
 

--- a/tests/Euterpe.Tests/Core/Services/ChartManageService/ChartManageServiceTest.cs
+++ b/tests/Euterpe.Tests/Core/Services/ChartManageService/ChartManageServiceTest.cs
@@ -39,14 +39,17 @@ public sealed partial class ChartManageServiceTest
         await Assert.That(charts[0].Manifest.Meta.Name).IsEqualTo("before");
     }
 
-    private static ChartManageService CreateService(IChartLocalService localService) =>
+    private static ChartManageService CreateService(
+        IChartLocalService localService,
+        IGameDownloadManager? gameDownloadManager = null,
+        IFileSystemService? fileSystemService = null) =>
         new()
         {
             GameConfig = new MuseDashConfig(),
             Archive = IArchiveService.Mock(),
             ChartLocalService = localService,
-            FileSystemService = IFileSystemService.Mock(),
-            GameDownloadManager = IGameDownloadManager.Mock(),
+            FileSystemService = fileSystemService ?? IFileSystemService.Mock(),
+            GameDownloadManager = gameDownloadManager ?? IGameDownloadManager.Mock(),
             Logger = Mock.Logger<ChartManageService>(),
             NotificationService = INotificationService.Mock(),
             MigrationService = IMigrationService.Mock()

--- a/tests/Euterpe.Tests/Models/Charts/ChartFilesTest.cs
+++ b/tests/Euterpe.Tests/Models/Charts/ChartFilesTest.cs
@@ -1,0 +1,41 @@
+namespace Euterpe.Tests.Models.Charts;
+
+[Category("ChartFilesTests")]
+[TestSubject(typeof(ChartFiles))]
+public sealed class ChartFilesTest
+{
+    [Test]
+    [Arguments("manifest.epk")]
+    [Arguments("music.ogg")]
+    [Arguments("demo.ogg")]
+    [Arguments("video.mp4")]
+    [Arguments("cover.webp")]
+    [Arguments("cover.gif")]
+    [Arguments("cover.png")]
+    [Arguments("map1.bms")]
+    [Arguments("map4.bms")]
+    [Arguments("map3.talk")]
+    public async Task IsChartFile_KnownOrRetiredChartFile_ReturnsTrue(string fileName) =>
+        await Assert.That(ChartFiles.IsChartFile(fileName)).IsTrue();
+
+    [Test]
+    [Arguments("thumbs.db")]
+    [Arguments("music.ogg.tmp")]
+    [Arguments("notes.txt")]
+    [Arguments("song.mp3")]
+    [Arguments("map.bms")]
+    [Arguments("mapx.bms")]
+    [Arguments("covers.png")]
+    public async Task IsChartFile_ForeignFile_ReturnsFalse(string fileName) =>
+        await Assert.That(ChartFiles.IsChartFile(fileName)).IsFalse();
+
+    [Test]
+    [Arguments("cover.webp", true)]
+    [Arguments("cover.gif", true)]
+    [Arguments("cover.png", true)]
+    [Arguments("cover.jpg", true)]
+    [Arguments("music.ogg", false)]
+    [Arguments("covers.png", false)]
+    public async Task IsCoverFile_StemIsCover_MatchesAnyExtension(string fileName, bool expected) =>
+        await Assert.That(ChartFiles.IsCoverFile(fileName)).IsEqualTo(expected);
+}


### PR DESCRIPTION
Reworks `POST /api/charts/check-updates` from a one-way (download-only) diff into a true per-file diff, so the App can delete individual files within a chart — not just whole charts.

## Why
The old response carried per-cid files to download plus whole-chart removals (`{updates, removed}`), with no way to express a single file being deleted within a chart. After the server's `cover.png` → `cover.webp` migration, clients downloaded the new webp but never removed the stale png; any chart whose file set shrank left orphans on disk.

## What
Per-cid response is now `{changed, deleted}`:
- **changed** — files to (re)download. `manifest.epk` is omitted when any non-epk file is present (implied) and re-added by the client, since every live change bumps the manifest. A pure orphan cleanup downloads nothing (stays network-free).
- **deleted** — files to remove. `manifest.epk` in `deleted` is the tombstone signal for a removed/delisted chart (replacing the old `removed[cid]`), checked first.

The request now reports the on-disk chart files (filtered to the chart-file whitelist via `ChartFiles.IsChartFile`) instead of just the manifest entries, so the server's reverse diff prunes any orphan the manifest no longer lists — including covers left behind by the migration. `UpdateChartAsync` deletes the flagged files in the work folder before the atomic swap; the per-chart disk scan that builds the request runs off the UI thread.

Cover rendering itself (webp preference) already landed on `dev` (6d555a5e / b085792c), so this PR does not touch `CoverExtensions` — the whitelist's `IsChartFile` still recognises legacy `cover.png` so the reverse diff can prune it.

## Lockstep with the backend
The wire contract was frozen with the Euterpe.Web side (matching `feat/chart-sync-per-file-diff` branch); web computes the bidirectional diff and emits the same `{charts:{cid:{changed,deleted}}}` shape. **Breaking change — deploy both together.** Cross-review also caught and fixed a server-side client-data-loss edge (empty `files_state` on a live chart → mass deletion), guarded on the web side.

## Tests
New `ChartFilesTest` (whitelist taxonomy incl. legacy png / map.talk / foreign files) and `ChartManageServiceTest.Update` (tombstone pruning, changed+deleted routing). Builds + targeted tests green on the `dev` base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)