### PR TITLE
Replace the about page loading spinner with a contributor skeleton

### DIFF
--- a/src/Euterpe.Controls/Controls/ContributorSkeleton/ContributorSkeleton.cs
+++ b/src/Euterpe.Controls/Controls/ContributorSkeleton/ContributorSkeleton.cs
@@ -1,0 +1,3 @@
+namespace Euterpe.Controls;
+
+public sealed class ContributorSkeleton : TemplatedControl;

--- a/src/Euterpe.Controls/Themes/Controls/ContributorSkeleton.axaml
+++ b/src/Euterpe.Controls/Themes/Controls/ContributorSkeleton.axaml
@@ -1,0 +1,92 @@
+<Styles
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:e="https://github.com/Euterpe-org/Euterpe">
+
+    <Styles.Resources>
+
+        <!--  Placeholder ink  -->
+        <ControlTheme
+            x:Key="ContributorSkeletonBar"
+            TargetType="Border">
+            <Setter Property="Background" Value="{DynamicResource SemiGrey1}" />
+            <Setter Property="CornerRadius" Value="4" />
+            <Setter Property="HorizontalAlignment" Value="Left" />
+        </ControlTheme>
+
+        <!--  ContributorCard's box, so the grid keeps its place when the data lands  -->
+        <ControlTheme
+            x:Key="ContributorSkeletonCard"
+            TargetType="ContentControl">
+            <Setter Property="Height" Value="140" />
+            <Setter Property="Margin" Value="8" />
+            <Setter Property="Width" Value="320" />
+            <Setter Property="Template">
+                <ControlTemplate>
+                    <Border
+                        Padding="36,0,0,0"
+                        Theme="{DynamicResource CardBorder}">
+                        <StackPanel
+                            Orientation="Horizontal"
+                            Spacing="10"
+                            VerticalAlignment="Center">
+                            <Border
+                                CornerRadius="32"
+                                Height="64"
+                                Theme="{StaticResource ContributorSkeletonBar}"
+                                Width="64" />
+                            <StackPanel
+                                Spacing="9"
+                                VerticalAlignment="Center">
+                                <Border
+                                    Height="14"
+                                    Theme="{StaticResource ContributorSkeletonBar}"
+                                    Width="104" />
+                                <Border
+                                    Height="9"
+                                    Theme="{StaticResource ContributorSkeletonBar}"
+                                    Width="150" />
+                                <Border
+                                    Height="9"
+                                    Theme="{StaticResource ContributorSkeletonBar}"
+                                    Width="96" />
+                            </StackPanel>
+                        </StackPanel>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+        </ControlTheme>
+
+    </Styles.Resources>
+
+    <Design.PreviewWith>
+        <e:ContributorSkeleton />
+    </Design.PreviewWith>
+
+    <Style
+        Selector="e|ContributorSkeleton">
+        <Setter Property="IsTabStop" Value="False" />
+        <Setter Property="Template">
+            <ControlTemplate>
+                <StackPanel
+                    Margin="0,16">
+
+                    <!--  Group heading; 4 + 16 + 5 is the H4 line box  -->
+                    <Border
+                        Height="16"
+                        Margin="0,4,0,5"
+                        Theme="{StaticResource ContributorSkeletonBar}"
+                        Width="132" />
+
+                    <WrapPanel>
+                        <ContentControl
+                            Theme="{StaticResource ContributorSkeletonCard}" />
+                        <ContentControl
+                            Theme="{StaticResource ContributorSkeletonCard}" />
+                    </WrapPanel>
+                </StackPanel>
+            </ControlTemplate>
+        </Setter>
+    </Style>
+
+</Styles>

--- a/src/Euterpe.Controls/Themes/EuterpeTheme.axaml
+++ b/src/Euterpe.Controls/Themes/EuterpeTheme.axaml
@@ -26,6 +26,8 @@
     <StyleInclude
         Source="/Themes/Controls/ContributorCard.axaml" />
     <StyleInclude
+        Source="/Themes/Controls/ContributorSkeleton.axaml" />
+    <StyleInclude
         Source="/Themes/Controls/CoverImage.axaml" />
     <StyleInclude
         Source="/Themes/Controls/DifficultyStar.axaml" />

--- a/src/Euterpe/Features/Setting/AboutPanel.axaml
+++ b/src/Euterpe/Features/Setting/AboutPanel.axaml
@@ -181,11 +181,9 @@
                 </Border>
 
                 <!--  Contributors  -->
-                <u:LoadingContainer
-                    IsLoading="{Binding !AllContributorsLoaded, Mode=OneWay}"
-                    LoadingMessage="{Localize {x:Static loc:XAMLLiteral.LoadingMessage}}"
-                    VerticalAlignment="Stretch"
-                    VerticalContentAlignment="Top">
+                <Panel>
+                    <e:ContributorSkeleton
+                        IsVisible="{Binding !AllContributorsLoaded, Mode=OneWay}" />
                     <ItemsControl
                         ItemsSource="{Binding ContributorGroups, Mode=OneWay}">
 
@@ -226,7 +224,7 @@
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
-                </u:LoadingContainer>
+                </Panel>
             </StackPanel>
         </DockPanel>
     </ScrollViewer>

--- a/tests/Euterpe.Headless.Tests/Controls/ContributorSkeletonTest.cs
+++ b/tests/Euterpe.Headless.Tests/Controls/ContributorSkeletonTest.cs
@@ -1,0 +1,42 @@
+namespace Euterpe.Headless.Tests.Controls;
+
+[TestSubject(typeof(ContributorSkeleton))]
+[Category("ContributorSkeletonTests")]
+public sealed class ContributorSkeletonTest : HeadlessTest
+{
+    [Test]
+    public Task PlaceholderCard_TakesTheSameBoxAsTheRealCard() => RunOnUI(async () =>
+    {
+        var skeleton = new ContributorSkeleton();
+        var card = new ContributorCard { ContributorName = "test", ContributorDescription = "the maintainer" };
+        Show(skeleton, card);
+
+        var placeholder = skeleton.GetVisualDescendants().OfType<ContentControl>().First();
+
+        await Assert.That(placeholder.Bounds.Size).IsEqualTo(card.Bounds.Size);
+    });
+
+    [Test]
+    public Task Placeholders_TakeTheirFillFromTheTheme() => RunOnUI(async () =>
+    {
+        var skeleton = new ContributorSkeleton();
+        Show(skeleton);
+
+        var unpainted = skeleton.GetVisualDescendants().OfType<Border>().Where(static border => border.Background is null);
+
+        await Assert.That(unpainted).IsEmpty();
+    });
+
+    private static void Show(params Control[] children)
+    {
+        var panel = new StackPanel();
+        foreach (var child in children)
+        {
+            panel.Children.Add(child);
+        }
+
+        var window = new Window { Content = panel, Width = 900, Height = 700 };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+    }
+}


### PR DESCRIPTION
The `LoadingContainer` sat in a vertical `StackPanel` with an empty `ItemsControl`, so it had no height to stretch into and collapsed to a 733x37 strip with a half-clipped spinner.

The placeholder holds `ContributorCard`'s box instead, so the grid keeps its place when the request lands.