### PR TITLE
Filter chart difficulties with the star icons

### DIFF
--- a/src/Euterpe/Features/Charting/ChartManagePanel.axaml
+++ b/src/Euterpe/Features/Charting/ChartManagePanel.axaml
@@ -32,6 +32,30 @@
             Selector="Button.Link:pointerover TextBlock">
             <Setter Property="TextDecorations" Value="Underline" />
         </Style>
+
+        <!--  Difficulty toggles: nothing but the star, so the chrome and the checked highlight both go  -->
+        <Style
+            Selector="ToggleButton.DifficultyFilter">
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Padding" Value="3" />
+        </Style>
+        <Style
+            Selector="ToggleButton.DifficultyFilter /template/ ContentPresenter">
+            <Setter Property="Background" Value="Transparent" />
+        </Style>
+        <Style
+            Selector="ToggleButton.DifficultyFilter:pointerover /template/ ContentPresenter">
+            <Setter Property="Background" Value="{DynamicResource SemiGrey1}" />
+        </Style>
+        <Style
+            Selector="ToggleButton.DifficultyFilter e|DifficultyStar">
+            <Setter Property="Height" Value="30" />
+            <Setter Property="Width" Value="30" />
+        </Style>
+        <Style
+            Selector="ToggleButton.DifficultyFilter:not(:checked) e|DifficultyStar">
+            <Setter Property="Opacity" Value="0.3" />
+        </Style>
     </UserControl.Styles>
 
     <Grid
@@ -190,18 +214,38 @@
                                 <TextBlock
                                     FontWeight="SemiBold"
                                     Text="{Localize {x:Static loc:XAMLLiteral.ChartManage_Filter_Difficulty}}" />
-                                <CheckBox
-                                    Content="{Localize {x:Static loc:XAMLLiteral.ChartDifficulty_Easy}}"
-                                    IsChecked="{Binding Filter.ShowEasy}" />
-                                <CheckBox
-                                    Content="{Localize {x:Static loc:XAMLLiteral.ChartDifficulty_Hard}}"
-                                    IsChecked="{Binding Filter.ShowHard}" />
-                                <CheckBox
-                                    Content="{Localize {x:Static loc:XAMLLiteral.ChartDifficulty_Master}}"
-                                    IsChecked="{Binding Filter.ShowMaster}" />
-                                <CheckBox
-                                    Content="{Localize {x:Static loc:XAMLLiteral.ChartDifficulty_Hidden}}"
-                                    IsChecked="{Binding Filter.ShowHidden}" />
+                                <StackPanel
+                                    Orientation="Horizontal"
+                                    Spacing="2">
+                                    <ToggleButton
+                                        Classes="DifficultyFilter"
+                                        IsChecked="{Binding Filter.ShowEasy}"
+                                        ToolTip.Tip="{Localize {x:Static loc:XAMLLiteral.ChartDifficulty_Easy}}">
+                                        <e:DifficultyStar
+                                            Difficulty="Easy" />
+                                    </ToggleButton>
+                                    <ToggleButton
+                                        Classes="DifficultyFilter"
+                                        IsChecked="{Binding Filter.ShowHard}"
+                                        ToolTip.Tip="{Localize {x:Static loc:XAMLLiteral.ChartDifficulty_Hard}}">
+                                        <e:DifficultyStar
+                                            Difficulty="Hard" />
+                                    </ToggleButton>
+                                    <ToggleButton
+                                        Classes="DifficultyFilter"
+                                        IsChecked="{Binding Filter.ShowMaster}"
+                                        ToolTip.Tip="{Localize {x:Static loc:XAMLLiteral.ChartDifficulty_Master}}">
+                                        <e:DifficultyStar
+                                            Difficulty="Master" />
+                                    </ToggleButton>
+                                    <ToggleButton
+                                        Classes="DifficultyFilter"
+                                        IsChecked="{Binding Filter.ShowHidden}"
+                                        ToolTip.Tip="{Localize {x:Static loc:XAMLLiteral.ChartDifficulty_Hidden}}">
+                                        <e:DifficultyStar
+                                            Difficulty="Hidden" />
+                                    </ToggleButton>
+                                </StackPanel>
                             </StackPanel>
 
                             <StackPanel

--- a/src/Euterpe/Features/Charting/ChartManagePanel.axaml
+++ b/src/Euterpe/Features/Charting/ChartManagePanel.axaml
@@ -176,7 +176,7 @@
                         <StackPanel
                             Margin="0,0,12,0"
                             Spacing="14">
-                            <!--  CTA to the web chart library  -->
+                            <!--  CTA to the web chart library; trimmed from the shared card metrics to fit the rail  -->
                             <Button
                                 Classes="Transparent Card"
                                 Command="{Binding OpenUrlCommand}"
@@ -190,10 +190,12 @@
                                     </Style>
                                 </Button.Styles>
                                 <Border
-                                    Classes="Hover">
+                                    Classes="Hover"
+                                    Padding="12">
                                     <StackPanel>
                                         <TextBlock
                                             Classes="CardTitle"
+                                            FontSize="20"
                                             Text="{Localize {x:Static loc:XAMLLiteral.ChartManage_GetCharts_Title}}">
                                             <TextBlock.Foreground>
                                                 <LinearGradientBrush StartPoint="0%,0%" EndPoint="100%,100%">
@@ -204,6 +206,7 @@
                                         </TextBlock>
                                         <TextBlock
                                             Classes="CardDesc"
+                                            Margin="0,3,0,0"
                                             Text="{Localize {x:Static loc:XAMLLiteral.ChartManage_GetCharts_Description}}" />
                                     </StackPanel>
                                 </Border>

--- a/tests/Euterpe.Headless.Tests/Views/ChartManagePanelTest.cs
+++ b/tests/Euterpe.Headless.Tests/Views/ChartManagePanelTest.cs
@@ -1,0 +1,55 @@
+using Avalonia.Controls.Primitives;
+using Euterpe.Features.Charting;
+using Euterpe.Models.Charts;
+
+namespace Euterpe.Headless.Tests.Views;
+
+[Category("ChartManagePanelTests")]
+[TestSubject(typeof(ChartManagePanel))]
+public sealed class ChartManagePanelTest : HeadlessTest
+{
+    [Test]
+    public Task DifficultyFilters_OnePerDifficulty() => RunOnUI(async () =>
+    {
+        var difficulties = DifficultyToggles(Show())
+            .Select(static toggle => toggle.GetVisualDescendants().OfType<DifficultyStar>().Single().Difficulty);
+
+        await Assert.That(difficulties).IsEquivalentTo(ChartDifficultyExtensions.GetValues());
+    });
+
+    [Test]
+    public Task DifficultyFilter_Toggled_DimsTheStarWithoutResizingIt() => RunOnUI(async () =>
+    {
+        var toggle = DifficultyToggles(Show())[0];
+        var star = toggle.GetVisualDescendants().OfType<DifficultyStar>().Single();
+        var litSize = star.Bounds.Size;
+
+        toggle.IsChecked = false;
+        Dispatcher.UIThread.RunJobs();
+        var dimmed = star.Opacity;
+        var dimmedSize = star.Bounds.Size;
+
+        toggle.IsChecked = true;
+        Dispatcher.UIThread.RunJobs();
+
+        using var _ = Assert.Multiple();
+        await Assert.That(dimmed).IsLessThan(1);
+        await Assert.That(dimmedSize).IsEqualTo(litSize);
+        await Assert.That(star.Opacity).IsEqualTo(1);
+    });
+
+    private static List<ToggleButton> DifficultyToggles(ChartManagePanel view) =>
+        view.GetVisualDescendants()
+            .OfType<ToggleButton>()
+            .Where(static toggle => toggle.Classes.Contains("DifficultyFilter"))
+            .ToList();
+
+    private static ChartManagePanel Show()
+    {
+        var view = new ChartManagePanel();
+        var window = new Window { Content = view, Width = 1000, Height = 700 };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        return view;
+    }
+}


### PR DESCRIPTION
The difficulty filter was four stacked checkboxes carrying the same information the cover badge already shows as a colour. It is one row of stars now: full colour when selected, dimmed when not, so the hue still says which difficulty it is.

Dimming rather than greying or outlining is deliberate — an outline redraws the silhouette (`Stretch="Uniform"` fits the geometry inside the stroke, which rounds off the notches), and a neutral grey throws away the only thing identifying the difficulty now that the labels are gone. `DifficultyStar` itself is untouched.

Second commit shortens the get-charts card in the same rail from 133px to 96px. Its metrics come from the `Hover`/`CardTitle`/`CardDesc` classes, which are sized for the full-width cards on `CharterToolkitPanel` and `ModDevelopPanel`; the shared classes are left alone and only this card overrides them.